### PR TITLE
Fix OAuth CSRF cookie Secure flag for development

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -72,6 +72,7 @@ if settings.google_client_id and settings.google_client_secret:
             settings.secret_key,
             redirect_url=f"{settings.frontend_url}/callback/google",
             associate_by_email=True,
+            csrf_token_cookie_secure=not settings.is_development,
         ),
         prefix="/auth/google",
         tags=["auth"],


### PR DESCRIPTION
## Summary

fastapi-users 15 defaults the OAuth CSRF cookie to `Secure=True`. Browsers silently drop Secure cookies on plain HTTP (localhost), breaking the entire Google OAuth flow in development.

Now sets `csrf_token_cookie_secure=False` in development, matching the existing pattern for auth cookies.

## Test plan

- [x] Tested Google OAuth end-to-end locally — flow completes and redirects to profile