### PR TITLE
Add iss (issuer) claim to JWTs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,12 @@ ENVIRONMENT=development
 # CORS — comma-separated additional origins (*.criticalbit.gg is always allowed in production)
 CORS_ORIGINS=
 
+# API public URL (used for OAuth callback redirect_uri in production, and as JWT issuer default)
+API_URL=http://localhost:8000
+
+# JWT issuer claim — defaults to API_URL if not set
+TOKEN_ISSUER=
+
 # Frontend URL (auth frontend for redirects after OAuth callbacks)
 FRONTEND_URL=http://localhost:5173
 

--- a/app/auth/backend.py
+++ b/app/auth/backend.py
@@ -1,9 +1,25 @@
+from fastapi_users import models
 from fastapi_users.authentication import AuthenticationBackend, CookieTransport, JWTStrategy
+from fastapi_users.jwt import generate_jwt
 
 from app.auth.keys import private_key_pem, public_key_pem
 from app.config import settings
 
 ACCESS_TOKEN_LIFETIME = 900  # 15 minutes
+
+
+class IssuingJWTStrategy(JWTStrategy):
+    """JWTStrategy subclass that adds an ``iss`` claim to every token."""
+
+    async def write_token(self, user: models.UP) -> str:
+        data = {
+            "sub": str(user.id),
+            "aud": self.token_audience,
+            "iss": settings.jwt_issuer,
+        }
+        return generate_jwt(
+            data, self.encode_key, self.lifetime_seconds, algorithm=self.algorithm
+        )
 
 cookie_transport = CookieTransport(
     cookie_name="app_access",
@@ -16,8 +32,8 @@ cookie_transport = CookieTransport(
 )
 
 
-def get_jwt_strategy() -> JWTStrategy:
-    return JWTStrategy(
+def get_jwt_strategy() -> IssuingJWTStrategy:
+    return IssuingJWTStrategy(
         secret=private_key_pem,
         lifetime_seconds=ACCESS_TOKEN_LIFETIME,
         algorithm="RS256",

--- a/app/auth/backend.py
+++ b/app/auth/backend.py
@@ -17,9 +17,8 @@ class IssuingJWTStrategy(JWTStrategy):
             "aud": self.token_audience,
             "iss": settings.jwt_issuer,
         }
-        return generate_jwt(
-            data, self.encode_key, self.lifetime_seconds, algorithm=self.algorithm
-        )
+        return generate_jwt(data, self.encode_key, self.lifetime_seconds, algorithm=self.algorithm)
+
 
 cookie_transport = CookieTransport(
     cookie_name="app_access",

--- a/app/auth/refresh.py
+++ b/app/auth/refresh.py
@@ -1,8 +1,9 @@
 import uuid
 from datetime import UTC, datetime, timedelta
 
+import jwt
 from fastapi import Response
-from fastapi_users.jwt import decode_jwt, generate_jwt
+from fastapi_users.jwt import generate_jwt
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -39,6 +40,7 @@ async def create_refresh_token(
         "jti": str(token_id),
         "family": token_family,
         "aud": REFRESH_AUDIENCE,
+        "iss": settings.jwt_issuer,
     }
     return generate_jwt(
         jwt_data,
@@ -53,11 +55,12 @@ async def validate_and_rotate_refresh_token(
     session: AsyncSession,
 ) -> tuple[str, str] | None:
     try:
-        payload = decode_jwt(
+        payload = jwt.decode(
             token_jwt,
-            secret=public_key_pem,
+            public_key_pem,
             audience=REFRESH_AUDIENCE,
             algorithms=["RS256"],
+            issuer=settings.jwt_issuer,
         )
     except Exception:
         return None
@@ -98,10 +101,10 @@ async def validate_and_rotate_refresh_token(
     return (user_id, new_jwt)
 
 
-def set_refresh_cookie(response: Response, jwt: str) -> None:
+def set_refresh_cookie(response: Response, token: str) -> None:
     response.set_cookie(
         key=REFRESH_COOKIE_NAME,
-        value=jwt,
+        value=token,
         max_age=int(REFRESH_TOKEN_LIFETIME.total_seconds()),
         path="/auth/refresh",
         domain=settings.cookie_domain,

--- a/app/config.py
+++ b/app/config.py
@@ -49,6 +49,9 @@ class Settings(BaseSettings):
     # Cookie auth
     cookie_domain: str | None = None
 
+    # JWT issuer — defaults to api_url
+    token_issuer: str = ""
+
     # Logging
     log_level: str = "INFO"
 
@@ -56,6 +59,10 @@ class Settings(BaseSettings):
     otel_enabled: bool = False
     otel_service_name: str = "criticalbit-auth-api"
     otel_exporter_endpoint: str = "http://localhost:4317"
+
+    @property
+    def jwt_issuer(self) -> str:
+        return self.token_issuer or self.api_url
 
     @property
     def is_development(self) -> bool:


### PR DESCRIPTION
## Summary
- Subclass `JWTStrategy` with `IssuingJWTStrategy` to add `iss` claim to access tokens
- Add `iss` claim to refresh tokens and validate it during token rotation
- New `TOKEN_ISSUER` setting (defaults to `API_URL` if not set)

## Deployment notes
After deploying, set `AUTH_TOKEN_ISSUER` in the Vagrant Story API to match this service's issuer value (the `API_URL`, e.g. `https://auth-api.criticalbit.gg`). The VS API already supports optional issuer validation and will start enforcing it once the env var is set.

Existing tokens without `iss` will naturally expire (15min access, 7day refresh), so there's no breaking change during rollout.

## Test plan
- [ ] Deploy to staging and log in — verify the access token JWT now contains an `iss` claim
- [ ] Verify token refresh still works (refresh token also has `iss`)
- [ ] Set `AUTH_TOKEN_ISSUER` in the VS API and verify authenticated endpoints still work