### PR TITLE
Add GCP Cloud Run deploy workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_call:
 
 jobs:
   lint:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,51 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+env:
+  GCP_PROJECT: criticalbit-production
+  GCP_REGION: us-east1
+  SERVICE_NAME: criticalbit-auth-api
+  IMAGE: us-east1-docker.pkg.dev/criticalbit-production/criticalbit-auth-api/criticalbit-auth-api
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+
+  deploy:
+    needs: ci
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/866878908346/locations/global/workloadIdentityPools/github-actions/providers/github-provider
+          service_account: github-actions-deploy@criticalbit-production.iam.gserviceaccount.com
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - run: gcloud auth configure-docker us-east1-docker.pkg.dev --quiet
+
+      - name: Build and push
+        run: |
+          docker build -t ${{ env.IMAGE }}:${{ github.sha }} -t ${{ env.IMAGE }}:latest .
+          docker push ${{ env.IMAGE }}:${{ github.sha }}
+          docker push ${{ env.IMAGE }}:latest
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run services update ${{ env.SERVICE_NAME }} \
+            --image ${{ env.IMAGE }}:${{ github.sha }} \
+            --region ${{ env.GCP_REGION }} \
+            --project ${{ env.GCP_PROJECT }}


### PR DESCRIPTION
## Summary
- Adds `deploy.yml` workflow: build → push to Artifact Registry → deploy to Cloud Run
- Updates `ci.yml` with `workflow_call` trigger so deploy gates on lint + tests passing
- Uses Workload Identity Federation for GCP auth (no static keys)
- Triggers on push to main only

## Test plan
- [ ] Merge this PR — the merge triggers the deploy workflow
- [ ] Verify the workflow runs successfully in the Actions tab
- [ ] Verify the deployed version is live at `https://auth-api.criticalbit.gg/health`