### PR TITLE
chore(security): add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @amrtgaber


### PR DESCRIPTION
## Summary

Add `.github/CODEOWNERS` requiring review from @amrtgaber on all paths. Consistent CODEOWNERS rollout across all criticalbit repos.

## Test plan

- [ ] CI passes