### PR TITLE
feat: add user_consents table and /user/consents endpoints

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -10,7 +10,7 @@ from app.config import settings
 from app.database import Base
 
 # Import all models so Alembic can detect them
-from app.models import OAuthAccount, RefreshToken, User  # noqa: F401
+from app.models import OAuthAccount, RefreshToken, User, UserConsent  # noqa: F401
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/alembic/versions/4ed6f02debb9_add_user_consents_table.py
+++ b/alembic/versions/4ed6f02debb9_add_user_consents_table.py
@@ -1,0 +1,60 @@
+"""add user_consents table
+
+Revision ID: 4ed6f02debb9
+Revises: ffa6fc175c0f
+Create Date: 2026-04-12 20:10:21.179907
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "4ed6f02debb9"
+down_revision: str | Sequence[str] | None = "ffa6fc175c0f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "user_consents",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("consent_type", sa.String(length=50), nullable=False),
+        sa.Column("consent_version", sa.String(length=20), nullable=False),
+        sa.Column("consented", sa.Boolean(), nullable=False),
+        sa.Column(
+            "consented_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("ip_hash", sa.String(length=64), nullable=True),
+        sa.Column("user_agent", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "idx_user_consents_latest",
+        "user_consents",
+        ["user_id", "consent_type", "consented_at"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_user_consents_user_id"),
+        "user_consents",
+        ["user_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_user_consents_user_id"), table_name="user_consents")
+    op.drop_index("idx_user_consents_latest", table_name="user_consents")
+    op.drop_table("user_consents")

--- a/app/consent/__init__.py
+++ b/app/consent/__init__.py
@@ -1,0 +1,3 @@
+from app.consent.constants import CONSENT_TYPES, CURRENT_POLICY_VERSION
+
+__all__ = ["CONSENT_TYPES", "CURRENT_POLICY_VERSION"]

--- a/app/consent/constants.py
+++ b/app/consent/constants.py
@@ -1,0 +1,6 @@
+# Must stay in sync with the "Last updated" date in the privacy policy at
+# criticalbit-web/src/pages/privacy/privacy-page.tsx. Bumping this string
+# re-prompts every user on their next authenticated page load.
+CURRENT_POLICY_VERSION = "2026-04-12"
+
+CONSENT_TYPES: frozenset[str] = frozenset({"analytics", "session_replay"})

--- a/app/main.py
+++ b/app/main.py
@@ -21,7 +21,7 @@ from app.database import get_async_session
 from app.features import router as features_router
 from app.logging import setup_logging
 from app.models.user import User
-from app.routers import admin_router
+from app.routers import admin_router, user_consent_router
 from app.routers.auth_refresh import router as auth_refresh_router
 from app.schemas.user import UserCreate, UserRead
 from app.telemetry import setup_telemetry
@@ -273,6 +273,7 @@ async def request_logging_middleware(request: Request, call_next) -> Response:
 
 # API routes
 app.include_router(admin_router)
+app.include_router(user_consent_router)
 app.include_router(features_router)
 
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,5 +1,6 @@
 from app.models.oauth_account import OAuthAccount
 from app.models.refresh_token import RefreshToken
 from app.models.user import User
+from app.models.user_consent import UserConsent
 
-__all__ = ["OAuthAccount", "RefreshToken", "User"]
+__all__ = ["OAuthAccount", "RefreshToken", "User", "UserConsent"]

--- a/app/models/user_consent.py
+++ b/app/models/user_consent.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class UserConsent(Base):
+    """Append-only record of a user's consent decisions.
+
+    A new row is inserted every time the user changes a consent; rows are
+    never updated. The latest decision for a (user_id, consent_type) pair
+    is the row with the largest consented_at value.
+    """
+
+    __tablename__ = "user_consents"
+
+    id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, default=uuid4)
+    user_id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    consent_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    consent_version: Mapped[str] = mapped_column(String(20), nullable=False)
+    consented: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    consented_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    ip_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    user_agent: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    __table_args__ = (
+        Index(
+            "idx_user_consents_latest",
+            "user_id",
+            "consent_type",
+            "consented_at",
+        ),
+    )

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,3 +1,4 @@
 from app.routers.admin import router as admin_router
+from app.routers.user_consent import router as user_consent_router
 
-__all__ = ["admin_router"]
+__all__ = ["admin_router", "user_consent_router"]

--- a/app/routers/user_consent.py
+++ b/app/routers/user_consent.py
@@ -1,0 +1,101 @@
+import hashlib
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import current_active_user
+from app.consent import CONSENT_TYPES, CURRENT_POLICY_VERSION
+from app.database import get_async_session
+from app.models.user import User
+from app.models.user_consent import UserConsent
+from app.schemas.user_consent import (
+    ConsentEntryRead,
+    ConsentsCreate,
+    ConsentsResponse,
+)
+
+router = APIRouter(prefix="/user/consents", tags=["consent"])
+
+
+def _hash_ip(ip: str | None) -> str | None:
+    if not ip:
+        return None
+    return hashlib.sha256(ip.encode("utf-8")).hexdigest()
+
+
+async def _latest_per_type(session: AsyncSession, user_id) -> dict[str, UserConsent]:
+    """Return the most recent UserConsent row per consent_type for a user."""
+    stmt = (
+        select(UserConsent)
+        .where(UserConsent.user_id == user_id)
+        .order_by(UserConsent.consented_at.desc())
+    )
+    result = await session.execute(stmt)
+    latest: dict[str, UserConsent] = {}
+    for row in result.scalars():
+        if row.consent_type not in latest:
+            latest[row.consent_type] = row
+    return latest
+
+
+def _to_response(latest: dict[str, UserConsent]) -> ConsentsResponse:
+    entries = {
+        ctype: ConsentEntryRead(
+            consented=row.consented,
+            version=row.consent_version,
+            consented_at=row.consented_at,
+            is_stale=row.consent_version != CURRENT_POLICY_VERSION,
+        )
+        for ctype, row in latest.items()
+    }
+    return ConsentsResponse(
+        current_policy_version=CURRENT_POLICY_VERSION,
+        consents=entries,
+    )
+
+
+@router.get("", response_model=ConsentsResponse)
+async def get_consents(
+    user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_async_session),
+):
+    latest = await _latest_per_type(session, user.id)
+    return _to_response(latest)
+
+
+@router.post("", response_model=ConsentsResponse)
+async def post_consents(
+    body: ConsentsCreate,
+    request: Request,
+    user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_async_session),
+):
+    unknown = [entry.type for entry in body.consents if entry.type not in CONSENT_TYPES]
+    if unknown:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unknown consent type(s): {unknown}",
+        )
+
+    client_ip = request.client.host if request.client else None
+    user_agent = request.headers.get("user-agent")
+    now = datetime.now(UTC)
+
+    for entry in body.consents:
+        session.add(
+            UserConsent(
+                user_id=user.id,
+                consent_type=entry.type,
+                consent_version=CURRENT_POLICY_VERSION,
+                consented=entry.consented,
+                consented_at=now,
+                ip_hash=_hash_ip(client_ip),
+                user_agent=user_agent,
+            )
+        )
+    await session.commit()
+
+    latest = await _latest_per_type(session, user.id)
+    return _to_response(latest)

--- a/app/schemas/user_consent.py
+++ b/app/schemas/user_consent.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from app.consent import CONSENT_TYPES
+
+
+class ConsentEntryRead(BaseModel):
+    consented: bool
+    version: str
+    consented_at: datetime
+    is_stale: bool
+
+
+class ConsentsResponse(BaseModel):
+    current_policy_version: str
+    consents: dict[str, ConsentEntryRead]
+
+
+class ConsentEntryCreate(BaseModel):
+    type: str = Field(..., max_length=50)
+    consented: bool
+
+    def validated_type(self) -> str:
+        if self.type not in CONSENT_TYPES:
+            raise ValueError(f"Unknown consent type '{self.type}'")
+        return self.type
+
+
+class ConsentsCreate(BaseModel):
+    consents: list[ConsentEntryCreate]

--- a/tests/test_user_consent.py
+++ b/tests/test_user_consent.py
@@ -1,0 +1,131 @@
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.consent import CURRENT_POLICY_VERSION
+from app.models.user import User
+from app.models.user_consent import UserConsent
+
+
+@pytest.fixture
+async def persisted_user(session: AsyncSession, test_user: User) -> User:
+    """Insert the default test_user into the DB so consent rows can FK to it."""
+    session.add(test_user)
+    await session.commit()
+    return test_user
+
+
+class TestGetConsents:
+    async def test_anonymous_returns_401(self, client: AsyncClient):
+        response = await client.get("/user/consents")
+        assert response.status_code == 401
+
+    async def test_authenticated_with_no_records_returns_empty(
+        self, auth_client: AsyncClient, persisted_user: User
+    ):
+        response = await auth_client.get("/user/consents")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["current_policy_version"] == CURRENT_POLICY_VERSION
+        assert data["consents"] == {}
+
+
+class TestPostConsents:
+    async def test_post_creates_records_then_get_returns_them(
+        self,
+        auth_client: AsyncClient,
+        persisted_user: User,
+    ):
+        post_response = await auth_client.post(
+            "/user/consents",
+            json={
+                "consents": [
+                    {"type": "analytics", "consented": True},
+                    {"type": "session_replay", "consented": False},
+                ]
+            },
+        )
+        assert post_response.status_code == 200
+        post_data = post_response.json()
+        assert post_data["current_policy_version"] == CURRENT_POLICY_VERSION
+        assert post_data["consents"]["analytics"]["consented"] is True
+        assert post_data["consents"]["analytics"]["version"] == CURRENT_POLICY_VERSION
+        assert post_data["consents"]["analytics"]["is_stale"] is False
+        assert post_data["consents"]["session_replay"]["consented"] is False
+
+        get_response = await auth_client.get("/user/consents")
+        assert get_response.status_code == 200
+        assert get_response.json() == post_data
+
+    async def test_latest_wins_on_repeated_posts(
+        self,
+        auth_client: AsyncClient,
+        persisted_user: User,
+        session: AsyncSession,
+    ):
+        await auth_client.post(
+            "/user/consents",
+            json={"consents": [{"type": "analytics", "consented": True}]},
+        )
+        await auth_client.post(
+            "/user/consents",
+            json={"consents": [{"type": "analytics", "consented": False}]},
+        )
+
+        get_response = await auth_client.get("/user/consents")
+        assert get_response.status_code == 200
+        assert get_response.json()["consents"]["analytics"]["consented"] is False
+
+        # Both rows still exist — append-only semantics.
+        from sqlalchemy import select
+
+        result = await session.execute(
+            select(UserConsent).where(UserConsent.user_id == persisted_user.id)
+        )
+        rows = result.scalars().all()
+        assert len(rows) == 2
+
+    async def test_unknown_consent_type_returns_400(
+        self, auth_client: AsyncClient, persisted_user: User
+    ):
+        response = await auth_client.post(
+            "/user/consents",
+            json={"consents": [{"type": "mind_reading", "consented": True}]},
+        )
+        assert response.status_code == 400
+        assert "mind_reading" in response.json()["detail"]
+
+    async def test_anonymous_post_returns_401(self, client: AsyncClient):
+        response = await client.post(
+            "/user/consents",
+            json={"consents": [{"type": "analytics", "consented": True}]},
+        )
+        assert response.status_code == 401
+
+
+class TestStaleFlag:
+    async def test_is_stale_when_stored_version_differs_from_current(
+        self,
+        auth_client: AsyncClient,
+        persisted_user: User,
+        session: AsyncSession,
+    ):
+        # Seed a row with an old version directly.
+        session.add(
+            UserConsent(
+                id=uuid4(),
+                user_id=persisted_user.id,
+                consent_type="analytics",
+                consent_version="1999-01-01",
+                consented=True,
+            )
+        )
+        await session.commit()
+
+        response = await auth_client.get("/user/consents")
+        assert response.status_code == 200
+        entry = response.json()["consents"]["analytics"]
+        assert entry["version"] == "1999-01-01"
+        assert entry["is_stale"] is True


### PR DESCRIPTION
## Summary
- New `user_consents` append-only table (migration `4ed6f02debb9`) with per-(user, type) index
- `GET /user/consents` returns latest-per-purpose state + `current_policy_version` + `is_stale` flag per entry
- `POST /user/consents` validates against a `CONSENT_TYPES` allowlist, hashes client IP (SHA-256, unsalted for dedup), stamps rows with `CURRENT_POLICY_VERSION`

This is PR 1 of 3 in the Phase 3 consent rollout. Frontends (PR 2 auth-web, PR 3 vagrant-story-web) consume these endpoints to gate PostHog persistence and Sentry Session Replay on explicit user consent. Design background in \`PHASE_3_CONSENT.md\`.

### Design notes
- **Append-only**: every decision creates a new row; withdrawal is just `consented=false`. Full audit trail, no mutation.
- **Per-purpose**: \`consent_type\` is a \`String(50)\` (not an enum) so new types don't require migrations.
- **Policy versioning**: \`CURRENT_POLICY_VERSION\` (\`app/consent/constants.py\`) must track the "Last updated" date in \`criticalbit-web/src/pages/privacy/privacy-page.tsx\`. Bumping triggers re-prompt on next page load via the \`is_stale\` flag.
- **Signup integration**: no custom signup hook — the frontend will call \`POST /user/consents\` right after register succeeds (simpler than overriding fastapi-users' register route).
- **CASCADE on user deletion**: consent rows drop with the user. Retention-for-audit is out of scope for Phase 3; revisit if legal requires.

## Test plan
- [x] 7 new tests in \`tests/test_user_consent.py\`; full suite 15/15 green
- [x] Anonymous GET/POST → 401
- [x] Authenticated GET with no rows → empty consents dict
- [x] POST creates rows, GET returns them
- [x] Repeated POSTs: latest wins, both rows preserved (append-only)
- [x] Unknown \`consent_type\` → 400 with the bad type in \`detail\`
- [x] \`is_stale\` correctly set when stored version ≠ current
- [x] Migration round-trips (\`upgrade head\` → \`downgrade -1\` → \`upgrade head\`) cleanly on real Postgres
- [x] \`ruff check\` and \`ruff format --check\` clean