### PR TITLE
ops: run alembic upgrade head on deploy via Cloud Run Job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,7 @@ env:
   GCP_PROJECT: criticalbit-production
   GCP_REGION: us-east1
   SERVICE_NAME: criticalbit-auth-api
+  MIGRATE_JOB_NAME: criticalbit-auth-api-migrate
   IMAGE: us-east1-docker.pkg.dev/criticalbit-production/criticalbit-auth-api/criticalbit-auth-api
 
 jobs:
@@ -42,6 +43,21 @@ jobs:
           docker build -t ${{ env.IMAGE }}:${{ github.sha }} -t ${{ env.IMAGE }}:latest .
           docker push ${{ env.IMAGE }}:${{ github.sha }}
           docker push ${{ env.IMAGE }}:latest
+
+      # Run migrations before swapping the service. --wait propagates the
+      # job's non-zero exit status to this step, which fails the workflow
+      # on migration errors and leaves the current service version
+      # running. The service update step below never fires in that case.
+      - name: Run database migrations
+        run: |
+          gcloud run jobs update ${{ env.MIGRATE_JOB_NAME }} \
+            --image ${{ env.IMAGE }}:${{ github.sha }} \
+            --region ${{ env.GCP_REGION }} \
+            --project ${{ env.GCP_PROJECT }}
+          gcloud run jobs execute ${{ env.MIGRATE_JOB_NAME }} \
+            --region ${{ env.GCP_REGION }} \
+            --project ${{ env.GCP_PROJECT }} \
+            --wait
 
       - name: Deploy to Cloud Run
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,13 @@ COPY pyproject.toml uv.lock* ./
 # Install dependencies
 RUN uv sync --frozen --no-dev
 
-# Copy application code
+# Copy application code and migration tooling. alembic/ and alembic.ini
+# ship in the image so the migration Cloud Run Job (which reuses this
+# same image) can run `alembic upgrade head` during deploy, before the
+# service is swapped.
 COPY app ./app
+COPY alembic ./alembic
+COPY alembic.ini ./alembic.ini
 
 # Expose port
 EXPOSE 8000


### PR DESCRIPTION
## Summary
Restores automatic database migrations in the deploy pipeline. We just hit the failure mode where PR #19's \`user_consents\` migration needed to be run manually against prod Cloud SQL — nobody did, and users clicking consent checkboxes in production got "Failed to save consent" because the table didn't exist. Migrations should never require human intervention during a normal deploy.

### Changes
- **Dockerfile**: \`COPY alembic ./alembic\` and \`COPY alembic.ini ./alembic.ini\` so the migration tooling ships in the image. Previously only \`app/\` was copied, which is why no form of "run alembic inside the container" was ever possible.
- **deploy.yml**: new "Run database migrations" step between image push and service update. It points an existing Cloud Run Job (\`criticalbit-auth-api-migrate\`) at the new image and executes it with \`--wait\`. The \`--wait\` flag propagates the job's exit status to the workflow step, so a failing migration fails this step and blocks the subsequent service update — the old revision keeps serving traffic until someone fixes the migration. Matches standard blue-green safety.

### Cloud Run Job provisioning
The migration job itself is infrastructure and was created once, out-of-band, via:

\`\`\`bash
gcloud run jobs create criticalbit-auth-api-migrate \\
  --image us-east1-docker.pkg.dev/.../criticalbit-auth-api:<bootstrap> \\
  --region us-east1 \\
  --project criticalbit-production \\
  --service-account criticalbit-auth-api-sa@criticalbit-production.iam.gserviceaccount.com \\
  --set-cloudsql-instances criticalbit-production:us-east1:criticalbit-db \\
  --set-secrets DATABASE_URL=auth-db-url:latest \\
  --command .venv/bin/alembic \\
  --args upgrade,head \\
  --max-retries 0 \\
  --task-timeout 300 \\
  --memory 512Mi
\`\`\`

Reuses the service's own \`criticalbit-auth-api-sa\` so the job inherits the same Cloud SQL / Secret Manager access without a new IAM grant. The workflow only ever \`update\`s and \`execute\`s this existing job — it never creates it.

### Why \`.venv/bin/alembic\` instead of \`uv run alembic\`
\`uv run\` attempts a dev-dep re-sync on every invocation, which downloaded \`ruff\`, \`virtualenv\`, and \`pygments\` at job start (visible in the first test run's logs). \`alembic\` is a main project dependency so it's already installed in \`.venv/bin\` by \`uv sync --frozen --no-dev\` at image build time. Invoking the binary directly saves ~1-2s of cold-start and avoids unnecessary network calls inside the job.

### Pre-merge verification
- [x] Dockerfile builds cleanly locally
- [x] \`.venv/bin/alembic --version\` reports \`alembic 1.18.1\` from inside the built container
- [x] Cloud Run Job created manually with bootstrap image, executed successfully against prod Cloud SQL (returned exit 0 as a no-op "already at head" since the \`user_consents\` migration was applied earlier today via cloud-sql-proxy)
- [x] \`uv run pytest\` — 15/15 pass
- [x] \`ruff check\` + \`ruff format --check\` — clean

### Post-merge verification
- [ ] CI + Deploy workflow on main runs green
- [ ] Migration job logs show \`alembic upgrade head\` running against the new image
- [ ] \`alembic_version\` table in prod remains at \`4ed6f02debb9\` (no new migrations in this PR, so it's a no-op)
- [ ] Service revision updates to the new SHA after the migration step succeeds