### PR TITLE
test: add consistency checks for CURRENT_POLICY_VERSION

### DIFF
--- a/tests/test_consent_version.py
+++ b/tests/test_consent_version.py
@@ -1,0 +1,62 @@
+"""Consistency checks for CURRENT_POLICY_VERSION.
+
+The privacy policy version lives in two places:
+
+- `app/consent/constants.py` in this repo (the authoritative constant
+  used when stamping consent rows and computing the `is_stale` flag)
+- `criticalbit-web/src/pages/privacy/privacy-page.tsx` in the sibling
+  frontend repo (the user-visible "Last updated" string)
+
+If those two drift apart, the re-prompt flow silently misbehaves:
+either users are re-prompted against a policy they already saw, or
+they keep acknowledging a stale version without realizing the text
+changed. The tests below guard against both:
+
+1. Format check — catches typos and non-ISO dates that would break
+   lexicographic ordering. Runs everywhere, including CI.
+2. Cross-repo string check — runs only when the sibling repo is
+   checked out next to this one on disk (typical local dev layout).
+   In CI the auth-api workflow only checks out this repo, so the
+   test skips cleanly rather than failing. Local dev runs still
+   catch drift before commit.
+"""
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from app.consent import CURRENT_POLICY_VERSION
+
+
+def test_current_policy_version_parses_as_iso_8601_date():
+    # Must be a valid YYYY-MM-DD string so string ordering matches
+    # chronological ordering — the re-prompt logic treats a stored
+    # consent as stale when its version string does not equal
+    # CURRENT_POLICY_VERSION, and future bumps need to be comparable.
+    parsed = date.fromisoformat(CURRENT_POLICY_VERSION)
+    assert parsed.isoformat() == CURRENT_POLICY_VERSION
+
+
+def test_current_policy_version_matches_privacy_page_when_sibling_checked_out():
+    privacy_page = (
+        Path(__file__).parents[2]
+        / "criticalbit-web"
+        / "src"
+        / "pages"
+        / "privacy"
+        / "privacy-page.tsx"
+    )
+    if not privacy_page.exists():
+        pytest.skip(
+            f"Sibling criticalbit-web repo not present at {privacy_page}; "
+            "cross-repo consistency check skipped. CI environments that "
+            "only check out criticalbit-auth-api hit this path."
+        )
+    content = privacy_page.read_text(encoding="utf-8")
+    assert CURRENT_POLICY_VERSION in content, (
+        f"CURRENT_POLICY_VERSION={CURRENT_POLICY_VERSION!r} not found in "
+        f"{privacy_page}. The auth-api constant and the privacy policy "
+        "page have drifted — bump both in lockstep when updating the "
+        "policy."
+    )


### PR DESCRIPTION
## Summary
Two tests guarding against silent drift between auth-api's \`CURRENT_POLICY_VERSION\` constant and the user-visible "Last updated" string in criticalbit-web's \`privacy-page.tsx\`. If those two diverge, the consent re-prompt logic misbehaves — users are either re-prompted against a policy they already saw, or keep acknowledging a stale version without realizing the text changed.

- **Format check** (\`test_current_policy_version_parses_as_iso_8601_date\`) — uses \`date.fromisoformat\` to assert the constant is a valid YYYY-MM-DD string. Catches typos and non-ISO formats that would break the lexicographic ordering the re-prompt logic depends on. Runs everywhere including CI.
- **Cross-repo string check** (\`test_current_policy_version_matches_privacy_page_when_sibling_checked_out\`) — anchors on \`Path(__file__).parents[2]\` to locate the sibling criticalbit-web repo on disk. If present, reads \`privacy-page.tsx\` and asserts \`CURRENT_POLICY_VERSION\` is a substring. If not present (the case for CI, which only checks out this repo), the test calls \`pytest.skip()\` with an explanatory reason.

The practical effect: local dev runs (where all criticalbit repos are siblings under a common parent) catch drift before commit. CI runs pass unconditionally as far as this test is concerned — they can't catch cross-repo drift because only one repo is available. This matches the doc's "Risks and gotchas #9" recommendation: "Worth a comment in both places linking them, and ideally a test that compares the constant against a string extracted from the privacy policy page."

Stronger alternatives considered and rejected:
- A dedicated CI workflow that checks out both repos — ~45 min of infrastructure for marginal additional coverage, since developer machines already catch it
- A scheduled integration test fetching the live \`/privacy\` page — flaky, network-dependent, and adds a dependency on deployed state being the source of truth

## Test plan
- [x] New file: \`tests/test_consent_version.py\`
- [x] \`uv run pytest tests/test_consent_version.py -v\` — 2/2 pass locally with sibling repo present
- [x] Verified the skip path: temporarily renamed \`criticalbit-web\` → \`criticalbit-web.test-hidden\` and re-ran; second test reports \`SKIPPED\` cleanly with the explanatory reason
- [x] Full suite: \`uv run pytest\` — 17/17 pass (8 pre-existing + 7 consent + 2 new)
- [x] \`ruff check\` and \`ruff format --check\` — clean