### PR TITLE
feat(observability): initialize Sentry SDK for FastAPI

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -60,6 +60,10 @@ class Settings(BaseSettings):
     otel_service_name: str = "criticalbit-auth-api"
     otel_exporter_endpoint: str = "http://localhost:4317"
 
+    # Sentry
+    sentry_dsn: str = ""
+    sentry_release: str = ""
+
     @property
     def jwt_issuer(self) -> str:
         return self.token_issuer or self.api_url
@@ -67,6 +71,10 @@ class Settings(BaseSettings):
     @property
     def is_development(self) -> bool:
         return self.environment == "development"
+
+    @property
+    def sentry_traces_sample_rate(self) -> float:
+        return 1.0 if self.is_development else 0.1
 
     @property
     def cookie_samesite(self) -> str:

--- a/app/main.py
+++ b/app/main.py
@@ -24,8 +24,10 @@ from app.models.user import User
 from app.routers import admin_router, user_consent_router
 from app.routers.auth_refresh import router as auth_refresh_router
 from app.schemas.user import UserCreate, UserRead
+from app.sentry import init_sentry
 from app.telemetry import setup_telemetry
 
+init_sentry()
 setup_logging()
 logger = structlog.get_logger("app.request")
 

--- a/app/sentry.py
+++ b/app/sentry.py
@@ -1,0 +1,26 @@
+"""Sentry SDK initialization for the FastAPI service.
+
+Init must run BEFORE FastAPI() is constructed so FastApiIntegration and
+StarletteIntegration can auto-instrument middleware. See app/main.py.
+"""
+
+import sentry_sdk
+
+from app.config import settings
+
+
+def init_sentry() -> None:
+    if not settings.sentry_dsn:
+        return
+
+    sentry_sdk.init(
+        dsn=settings.sentry_dsn,
+        environment=settings.environment,
+        release=settings.sentry_release or None,
+        # Disclosed in the privacy policy at criticalbit.gg/privacy.
+        send_default_pii=True,
+        traces_sample_rate=settings.sentry_traces_sample_rate,
+        profile_session_sample_rate=1.0,
+        profile_lifecycle="trace",
+        enable_logs=True,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "opentelemetry-sdk>=1.40.0",
     "opentelemetry-exporter-otlp-proto-grpc>=1.40.0",
     "opentelemetry-instrumentation-fastapi>=0.61b0",
+    "sentry-sdk[fastapi]>=2.35.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -408,6 +408,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "python-multipart" },
     { name = "resend" },
+    { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "slowapi" },
     { name = "sqlalchemy" },
     { name = "structlog" },
@@ -441,6 +442,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.13.0" },
     { name = "python-multipart", specifier = ">=0.0.22" },
     { name = "resend", specifier = ">=2.0.0" },
+    { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.35.0" },
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "sqlalchemy", specifier = ">=2.0.48" },
     { name = "structlog", specifier = ">=25.0.0" },
@@ -1428,6 +1430,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6c/25/3fc9114abf979a41673ce877c08016f8e660ad6cf508c3957f537d2e9fa9/ruff-0.15.6-py3-none-win32.whl", hash = "sha256:bbf67d39832404812a2d23020dda68fee7f18ce15654e96fb1d3ad21a5fe436c", size = 10616872, upload-time = "2026-03-12T23:05:42.451Z" },
     { url = "https://files.pythonhosted.org/packages/89/7a/09ece68445ceac348df06e08bf75db72d0e8427765b96c9c0ffabc1be1d9/ruff-0.15.6-py3-none-win_amd64.whl", hash = "sha256:aee25bc84c2f1007ecb5037dff75cef00414fdf17c23f07dc13e577883dca406", size = 11787271, upload-time = "2026-03-12T23:05:20.168Z" },
     { url = "https://files.pythonhosted.org/packages/7f/d0/578c47dd68152ddddddf31cd7fc67dc30b7cdf639a86275fda821b0d9d98/ruff-0.15.6-py3-none-win_arm64.whl", hash = "sha256:c34de3dd0b0ba203be50ae70f5910b17188556630e2178fd7d79fc030eb0d837", size = 11060497, upload-time = "2026-03-12T23:05:25.968Z" },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.58.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/b3/fb8291170d0e844173164709fc0fa0c221ed75a5da740c8746f2a83b4eb1/sentry_sdk-2.58.0.tar.gz", hash = "sha256:c1144d947352d54e5b7daa63596d9f848adf684989c06c4f5a659f0c85a18f6f", size = 438764, upload-time = "2026-04-13T17:23:26.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/eb/d875669993b762556ae8b2efd86219943b4c0864d22204d622a9aee3052b/sentry_sdk-2.58.0-py2.py3-none-any.whl", hash = "sha256:688d1c704ddecf382ea3326f21a67453d4caa95592d722b7c780a36a9d23109e", size = 460919, upload-time = "2026-04-13T17:23:24.675Z" },
+]
+
+[package.optional-dependencies]
+fastapi = [
+    { name = "fastapi" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds `sentry-sdk[fastapi]>=2.35.0` and a new `app/sentry.py` module with an `init_sentry()` function that is a no-op when `SENTRY_DSN` is unset, matching the pattern used in `vagrant-story-api`.
- Wires `init_sentry()` as the first module-level call in `app/main.py`, before `FastAPI(...)` is constructed. This ordering is load-bearing: Sentry's FastApiIntegration patches Starlette middleware registration, so it has to run before the app is built for request context and tracing to attach correctly.
- Adds `SENTRY_DSN` and `SENTRY_RELEASE` fields to `Settings`, plus a derived `sentry_traces_sample_rate` that defaults to 1.0 in development and 0.1 in production so dev trace visibility is free.
- `send_default_pii=True` is enabled, matching the disclosure in the privacy policy at criticalbit.gg/privacy.

No behavior change when `SENTRY_DSN` is unset — `init_sentry()` returns immediately, so existing deployments that haven't set the env var see a byte-compatible service.

## Test plan
- [x] `uv run ruff check` + `uv run ruff format --check` — pass
- [x] `uv run pytest` — 17/17 pass
- [x] Boot without `SENTRY_DSN`: `uv run uvicorn app.main:app` → `/health` 200, `/` 200, no errors
- [x] Boot with `SENTRY_DSN` set: `/health` 200, init silent, no exceptions
- [x] End-to-end Sentry delivery: `sentry_sdk.capture_message(...)` + `flush()` → event `2c6391d20e5d4c7bb025e33208c711c5` verified visible in the Sentry project
- [ ] CI green

## Follow-ups (separate PRs)
- `criticalbit-auth-web` — Sentry + PostHog wiring (shared web Sentry project)
- `criticalbit-web` — Sentry + PostHog wiring (same shared web Sentry project; replaces the current `lib/analytics.tsx` stub)