### PR TITLE
fix(cors): allow sentry-trace and baggage headers in preflight

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -46,7 +46,7 @@ app.add_middleware(
     allow_origin_regex=settings.cors_origin_regex,
     allow_credentials=True,
     allow_methods=["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
-    allow_headers=["Authorization", "Content-Type"],
+    allow_headers=["Authorization", "Content-Type", "sentry-trace", "baggage"],
 )
 
 # Rate limiting

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,44 @@
+"""CORS preflight regression tests.
+
+Sentry's browser SDK injects `sentry-trace` and `baggage` headers into
+cross-origin fetches when tracing is enabled. If the CORS allow-headers
+list doesn't include them, every traced request from a criticalbit.gg
+frontend gets rejected at the preflight with 400 and the real call
+never fires — which silently breaks login, registration, and any other
+POST/fetch path depending on Sentry's sample rate. This test locks
+those headers into the allowlist so the bug can't come back unnoticed.
+"""
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.parametrize(
+    "requested_headers",
+    [
+        "sentry-trace",
+        "baggage",
+        "sentry-trace, baggage",
+        "Authorization, Content-Type, sentry-trace, baggage",
+    ],
+)
+async def test_cors_preflight_allows_sentry_tracing_headers(
+    client: AsyncClient, requested_headers: str
+) -> None:
+    response = await client.options(
+        "/auth/register",
+        headers={
+            "Origin": "http://localhost:5173",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": requested_headers,
+        },
+    )
+
+    assert response.status_code == 200, (
+        f"preflight rejected with {response.status_code} for headers: {requested_headers}"
+    )
+    allowed = {
+        h.strip().lower() for h in response.headers["access-control-allow-headers"].split(",")
+    }
+    assert "sentry-trace" in allowed
+    assert "baggage" in allowed


### PR DESCRIPTION
## Summary

- Adds `sentry-trace` and `baggage` to the `CORSMiddleware` allow-headers list so Sentry-traced frontend requests pass CORS preflight instead of being rejected with 400.
- Adds a parametrized regression test covering the header variants the Sentry browser SDK actually sends.

## Why this matters

Sentry's browser SDK silently injects `sentry-trace` and `baggage` headers into every cross-origin `fetch`/`XHR` when tracing is enabled. Those headers are not CORS-safelisted, so the browser upgrades the request to a preflighted one. Our `CORSMiddleware` was configured with `allow_headers=["Authorization", "Content-Type"]`, so the preflight response didn't include `sentry-trace`/`baggage` in `Access-Control-Allow-Headers` — Starlette's CORS middleware then rejects the preflight with **400 Bad Request**, and the actual call never fires.

The failure was surfacing as sporadic login / registration / OAuth breakage across every `criticalbit.gg` frontend (auth.criticalbit.gg, vagrant-story-web local dev, etc.). Because Sentry samples traces, only *some* requests got the extra headers, so it looked like an intermittent flake rather than a hard bug.

Reproduced with curl:

```bash
curl -sI -X OPTIONS https://auth-api.criticalbit.gg/auth/google/authorize \
  -H 'Origin: https://auth.criticalbit.gg' \
  -H 'Access-Control-Request-Method: GET' \
  -H 'Access-Control-Request-Headers: sentry-trace,baggage'
# HTTP/2 400 (before this change)
# HTTP/2 200 (after)
```

## Test plan

- [x] New `tests/test_cors.py` — 4 parametrized cases exercising `sentry-trace`, `baggage`, both, and the full realistic header list. All pass.
- [x] Full existing test suite still green (21 passed).
- [x] `ruff check` clean, `ruff format` clean.
- [ ] After deploy: verify login / registration / Google OAuth / Steam OAuth flows on auth.criticalbit.gg (prod smoke test).