### PR TITLE
fix(steam): leave display_name null when personaname is unavailable

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -159,6 +159,18 @@ class ProfileUpdate(BaseModel):
     avatar_url: str | None = None
 
 
+def _normalize_optional_text(value: str | None) -> str | None:
+    """Coerce blank / whitespace-only strings to None for optional text fields.
+
+    Stops empty form submissions from overwriting a populated display_name (or
+    avatar_url) with `""`, which downstream consumers tend to render as-is.
+    """
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
 @app.patch("/auth/me", response_model=UserRead, tags=["auth"])
 async def update_current_user(
     updates: ProfileUpdate,
@@ -166,9 +178,9 @@ async def update_current_user(
     session: AsyncSession = Depends(get_async_session),
 ):
     if updates.display_name is not None:
-        user.display_name = updates.display_name
+        user.display_name = _normalize_optional_text(updates.display_name)
     if updates.avatar_url is not None:
-        user.avatar_url = updates.avatar_url
+        user.avatar_url = _normalize_optional_text(updates.avatar_url)
     session.add(user)
     await session.commit()
     await session.refresh(user)

--- a/app/routers/auth_steam.py
+++ b/app/routers/auth_steam.py
@@ -74,10 +74,13 @@ async def steam_callback(
     if not steam_id:
         raise HTTPException(status_code=400, detail="Steam authentication failed")
 
-    # Fetch Steam profile
+    # Fetch Steam profile. If GetPlayerSummaries fails / rate-limits / is
+    # disabled (no api key), leave display_name and avatar_url as None rather
+    # than falling back to the SteamID64 — both frontends already fall back to
+    # email when display_name is null, which is friendlier than a 17-digit id.
     profile = await _get_steam_profile(steam_id)
-    display_name = profile.get("personaname", f"Steam User {steam_id}")
-    avatar_url = profile.get("avatarfull")
+    display_name = _personaname(profile)
+    avatar_url = profile.get("avatarfull") or None
 
     # Find or create user, update avatar/name on every login
     user = await _find_or_create_user(session, steam_id, display_name, avatar_url)
@@ -141,31 +144,70 @@ async def _verify_openid_assertion(params: dict) -> str | None:
 
 
 async def _get_steam_profile(steam_id: str) -> dict:
-    """Fetch a Steam user's profile via the Steam Web API."""
+    """Fetch a Steam user's profile via the Steam Web API.
+
+    Returns an empty dict when the API key is unset, the request fails, the
+    response is malformed, or Steam returns no player. Callers must treat the
+    absence of `personaname` as "unknown" rather than substituting `steam_id`.
+    """
     if not settings.steam_api_key:
         return {}
 
     url = f"{STEAM_API_URL}/ISteamUser/GetPlayerSummaries/v0002/"
     params = {"key": settings.steam_api_key, "steamids": steam_id}
 
-    async with httpx.AsyncClient() as client:
-        resp = await client.get(url, params=params)
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(url, params=params)
+    except httpx.HTTPError as e:
+        logger.warning("steam.profile_fetch_error", steam_id=steam_id, error=str(e))
+        return {}
 
     if resp.status_code != 200:
         logger.warning("steam.profile_fetch_failed", steam_id=steam_id, status=resp.status_code)
         return {}
 
-    players = resp.json().get("response", {}).get("players", [])
+    try:
+        players = resp.json().get("response", {}).get("players", [])
+    except ValueError:
+        logger.warning("steam.profile_invalid_json", steam_id=steam_id)
+        return {}
     return players[0] if players else {}
+
+
+def _personaname(profile: dict) -> str | None:
+    """Extract a usable persona name from a Steam profile.
+
+    Returns None when:
+    - the profile is empty (GetPlayerSummaries failed or returned no players),
+    - `personaname` is missing or blank after stripping whitespace,
+    - `personaname` is literally the SteamID64 — some accounts default it that
+      way and surfacing a raw 17-digit number is worse than null, since the UI
+      falls back to email.
+    """
+    raw = profile.get("personaname")
+    if not isinstance(raw, str):
+        return None
+    name = raw.strip()
+    if not name:
+        return None
+    if name.isdigit() and len(name) >= 16:
+        return None
+    return name
 
 
 async def _find_or_create_user(
     session: AsyncSession,
     steam_id: str,
-    display_name: str,
+    display_name: str | None,
     avatar_url: str | None = None,
 ) -> User:
-    """Find an existing user linked to this Steam ID, or create a new one."""
+    """Find an existing user linked to this Steam ID, or create a new one.
+
+    On re-login for an existing user, profile fields are only refreshed when
+    Steam returned usable values. A transient GetPlayerSummaries failure must
+    not clobber a previously-good display_name or avatar.
+    """
     # Check if this Steam ID is already linked
     result = await session.execute(
         select(OAuthAccount).where(
@@ -176,10 +218,11 @@ async def _find_or_create_user(
     oauth_account = result.scalar_one_or_none()
 
     if oauth_account:
-        # Existing linked account — fetch and update profile
+        # Existing linked account — refresh profile only when we have new data
         user_result = await session.execute(select(User).where(User.id == oauth_account.user_id))
         user = user_result.unique().scalar_one()
-        user.display_name = display_name
+        if display_name:
+            user.display_name = display_name
         if avatar_url:
             user.avatar_url = avatar_url
         await session.commit()

--- a/tests/test_steam_display_name.py
+++ b/tests/test_steam_display_name.py
@@ -1,0 +1,393 @@
+"""Regression tests for Steam OAuth display_name handling.
+
+Locks down the contract from ag-tech-group/criticalbit-auth-api#26: the Steam
+callback must never write a SteamID64 (or a "Steam User <id>" placeholder)
+into `User.display_name`. When `ISteamUser/GetPlayerSummaries` fails or
+returns no usable persona name, `display_name` stays `None` so both frontends
+fall back to email rather than rendering a raw 17-digit number.
+
+This file covers both the pure-helper layer (`_personaname`,
+`_get_steam_profile`) and the persistence layer (`_find_or_create_user`),
+plus the PATCH /auth/me normalization path that also could have leaked the
+empty string into the column.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+import httpx
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.oauth_account import OAuthAccount
+from app.models.user import User
+from app.routers import auth_steam
+from app.routers.auth_steam import (
+    _find_or_create_user,
+    _get_steam_profile,
+    _personaname,
+)
+
+A_STEAM_ID = "76561198000000001"
+
+
+# --- _personaname --------------------------------------------------------
+
+
+class TestPersonaname:
+    def test_returns_personaname_when_present(self) -> None:
+        assert _personaname({"personaname": "gabe"}) == "gabe"
+
+    def test_strips_whitespace(self) -> None:
+        assert _personaname({"personaname": "  gabe  "}) == "gabe"
+
+    def test_empty_profile_returns_none(self) -> None:
+        assert _personaname({}) is None
+
+    def test_missing_field_returns_none(self) -> None:
+        assert _personaname({"avatarfull": "https://..."}) is None
+
+    def test_blank_string_returns_none(self) -> None:
+        assert _personaname({"personaname": ""}) is None
+
+    def test_whitespace_only_returns_none(self) -> None:
+        assert _personaname({"personaname": "   "}) is None
+
+    def test_steamid64_string_returns_none(self) -> None:
+        # The exact regression — Steam returning the SteamID64 as personaname
+        # must not be propagated to display_name.
+        assert _personaname({"personaname": A_STEAM_ID}) is None
+
+    def test_numeric_name_below_steamid_length_is_kept(self) -> None:
+        # Don't be over-eager: a short numeric handle is still a name.
+        assert _personaname({"personaname": "12345"}) == "12345"
+
+    def test_non_string_field_returns_none(self) -> None:
+        assert _personaname({"personaname": 12345}) is None
+
+
+# --- _get_steam_profile --------------------------------------------------
+
+
+class _MockTransport(httpx.AsyncBaseTransport):
+    def __init__(self, handler):
+        self._handler = handler
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        return self._handler(request)
+
+
+@pytest.fixture
+def patch_httpx(monkeypatch: pytest.MonkeyPatch):
+    """Replace httpx.AsyncClient with a version using a custom transport."""
+
+    def _patch(handler) -> None:
+        real_ctor = httpx.AsyncClient
+
+        def _factory(*args, **kwargs):
+            kwargs["transport"] = _MockTransport(handler)
+            return real_ctor(*args, **kwargs)
+
+        monkeypatch.setattr(auth_steam.httpx, "AsyncClient", _factory)
+
+    return _patch
+
+
+@pytest.fixture
+def steam_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Enable the Steam Web API code path."""
+    monkeypatch.setattr(auth_steam.settings, "steam_api_key", "test-key")
+
+
+class TestGetSteamProfile:
+    async def test_empty_when_api_key_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(auth_steam.settings, "steam_api_key", "")
+        assert await _get_steam_profile(A_STEAM_ID) == {}
+
+    async def test_returns_player_on_success(self, steam_api_key, patch_httpx) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={"response": {"players": [{"personaname": "gabe"}]}},
+            )
+
+        patch_httpx(handler)
+        profile = await _get_steam_profile(A_STEAM_ID)
+        assert profile == {"personaname": "gabe"}
+
+    async def test_empty_when_status_not_200(self, steam_api_key, patch_httpx) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(429, text="rate limited")
+
+        patch_httpx(handler)
+        assert await _get_steam_profile(A_STEAM_ID) == {}
+
+    async def test_empty_when_no_players_in_response(self, steam_api_key, patch_httpx) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"response": {"players": []}})
+
+        patch_httpx(handler)
+        assert await _get_steam_profile(A_STEAM_ID) == {}
+
+    async def test_empty_when_transport_raises(self, steam_api_key, patch_httpx) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("boom", request=request)
+
+        patch_httpx(handler)
+        assert await _get_steam_profile(A_STEAM_ID) == {}
+
+    async def test_empty_when_response_not_json(self, steam_api_key, patch_httpx) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text="<html>down for maintenance</html>")
+
+        patch_httpx(handler)
+        assert await _get_steam_profile(A_STEAM_ID) == {}
+
+
+# --- _find_or_create_user -----------------------------------------------
+
+
+class TestFindOrCreateUser:
+    async def test_new_user_with_personaname(self, session: AsyncSession) -> None:
+        user = await _find_or_create_user(session, A_STEAM_ID, "gabe", "https://avatar")
+        assert user.display_name == "gabe"
+        assert user.avatar_url == "https://avatar"
+
+    async def test_new_user_with_no_personaname_leaves_display_name_null(
+        self, session: AsyncSession
+    ) -> None:
+        # The regression: when Steam fetch fails, _personaname returns None.
+        # We MUST NOT write a steam-id-derived placeholder. The column stays null.
+        user = await _find_or_create_user(session, A_STEAM_ID, None, None)
+        assert user.display_name is None
+        assert user.avatar_url is None
+        # Sanity check: the steam id is NOT in any user-visible field.
+        assert A_STEAM_ID not in (user.display_name or "")
+
+    async def test_existing_user_keeps_display_name_when_fetch_fails(
+        self, session: AsyncSession
+    ) -> None:
+        # Seed an existing linked account with a good display_name.
+        existing = User(
+            id=uuid4(),
+            email=f"steam_{A_STEAM_ID}@users.criticalbit.gg",
+            hashed_password="!steam-oauth-no-password",
+            is_active=True,
+            is_verified=False,
+            display_name="gabe",
+            avatar_url="https://avatar/old.png",
+        )
+        session.add(existing)
+        await session.flush()
+        session.add(
+            OAuthAccount(
+                user_id=existing.id,
+                oauth_name="steam",
+                access_token="",
+                account_id=A_STEAM_ID,
+                account_email=existing.email,
+            )
+        )
+        await session.commit()
+
+        # Re-login while Steam API is unreachable: display_name=None, avatar=None.
+        refreshed = await _find_or_create_user(session, A_STEAM_ID, None, None)
+        assert refreshed.id == existing.id
+        assert refreshed.display_name == "gabe"  # preserved, not clobbered
+        assert refreshed.avatar_url == "https://avatar/old.png"
+
+    async def test_existing_user_updates_when_steam_returns_new_name(
+        self, session: AsyncSession
+    ) -> None:
+        existing = User(
+            id=uuid4(),
+            email=f"steam_{A_STEAM_ID}@users.criticalbit.gg",
+            hashed_password="!steam-oauth-no-password",
+            is_active=True,
+            is_verified=False,
+            display_name="gabe",
+        )
+        session.add(existing)
+        await session.flush()
+        session.add(
+            OAuthAccount(
+                user_id=existing.id,
+                oauth_name="steam",
+                access_token="",
+                account_id=A_STEAM_ID,
+                account_email=existing.email,
+            )
+        )
+        await session.commit()
+
+        refreshed = await _find_or_create_user(
+            session, A_STEAM_ID, "gaben", "https://avatar/new.png"
+        )
+        assert refreshed.display_name == "gaben"
+        assert refreshed.avatar_url == "https://avatar/new.png"
+
+
+# --- /auth/steam/callback end-to-end ------------------------------------
+
+
+class TestSteamCallbackEndToEnd:
+    """Drive the actual handler with a mocked Steam API to lock in the
+    `personaname == steam_id` case at the HTTP-contract layer.
+
+    The Steam router is only registered at app import time if STEAM_API_KEY
+    is set, so we conditionally include it here. The teardown removes it
+    to keep the route table identical to other tests.
+    """
+
+    @pytest.fixture(autouse=True)
+    def ensure_steam_router(self):
+        from app.main import app
+
+        already_present = any(getattr(r, "path", "") == "/auth/steam/callback" for r in app.routes)
+        if already_present:
+            yield
+            return
+        before = list(app.routes)
+        app.include_router(auth_steam.router)
+        try:
+            yield
+        finally:
+            app.router.routes = before
+
+    @pytest.fixture
+    def stub_openid(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def _ok(params: dict[str, Any]) -> str | None:
+            return A_STEAM_ID
+
+        monkeypatch.setattr(auth_steam, "_verify_openid_assertion", _ok)
+
+    async def test_callback_persists_null_when_personaname_is_steamid(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        stub_openid,
+        steam_api_key,
+        patch_httpx,
+    ) -> None:
+        # Steam returns the SteamID64 as personaname (the bug scenario).
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={"response": {"players": [{"personaname": A_STEAM_ID, "avatarfull": ""}]}},
+            )
+
+        patch_httpx(handler)
+
+        resp = await client.get("/auth/steam/callback", follow_redirects=False)
+        assert resp.status_code == 302, resp.text
+
+        users = (
+            (await session.execute(select(User).where(User.email.like("steam_%"))))
+            .unique()
+            .scalars()
+            .all()
+        )
+        assert len(users) == 1, users
+        assert users[0].display_name is None
+        assert users[0].avatar_url is None
+
+    async def test_callback_persists_null_when_profile_fetch_fails(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        stub_openid,
+        steam_api_key,
+        patch_httpx,
+    ) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(503, text="steam down")
+
+        patch_httpx(handler)
+
+        resp = await client.get("/auth/steam/callback", follow_redirects=False)
+        assert resp.status_code == 302, resp.text
+
+        users = (
+            (await session.execute(select(User).where(User.email.like("steam_%"))))
+            .unique()
+            .scalars()
+            .all()
+        )
+        assert len(users) == 1, users
+        assert users[0].display_name is None
+
+    async def test_callback_persists_personaname_on_success(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        stub_openid,
+        steam_api_key,
+        patch_httpx,
+    ) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "response": {
+                        "players": [
+                            {
+                                "personaname": "gabe",
+                                "avatarfull": "https://avatar/full.jpg",
+                            }
+                        ]
+                    }
+                },
+            )
+
+        patch_httpx(handler)
+
+        resp = await client.get("/auth/steam/callback", follow_redirects=False)
+        assert resp.status_code == 302, resp.text
+
+        users = (
+            (await session.execute(select(User).where(User.email.like("steam_%"))))
+            .unique()
+            .scalars()
+            .all()
+        )
+        assert len(users) == 1, users
+        assert users[0].display_name == "gabe"
+        assert users[0].avatar_url == "https://avatar/full.jpg"
+
+
+# --- PATCH /auth/me normalization ---------------------------------------
+
+
+class TestAuthMeBlankDisplayName:
+    async def test_blank_string_is_stored_as_null(
+        self, auth_client: AsyncClient, test_user: User
+    ) -> None:
+        test_user.display_name = "Some Old Name"
+        resp = await auth_client.patch("/auth/me", json={"display_name": ""})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["display_name"] is None
+
+    async def test_whitespace_only_is_stored_as_null(
+        self, auth_client: AsyncClient, test_user: User
+    ) -> None:
+        test_user.display_name = "Some Old Name"
+        resp = await auth_client.patch("/auth/me", json={"display_name": "   "})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["display_name"] is None
+
+    async def test_value_is_trimmed(self, auth_client: AsyncClient, test_user: User) -> None:
+        resp = await auth_client.patch("/auth/me", json={"display_name": "  gabe  "})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["display_name"] == "gabe"
+
+    async def test_omitted_field_does_not_clear_existing_value(
+        self, auth_client: AsyncClient, test_user: User
+    ) -> None:
+        test_user.display_name = "keep-me"
+        resp = await auth_client.patch("/auth/me", json={"avatar_url": "https://x"})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["display_name"] == "keep-me"


### PR DESCRIPTION
Fixes #26.

## Summary

- Steam OAuth callback no longer falls back to a SteamID64-derived placeholder for `display_name`. When `ISteamUser/GetPlayerSummaries` fails, returns no players, or omits a usable `personaname`, the column is left `null` so both frontends render the email-based fallback instead of a raw 17-digit number.
- `_find_or_create_user` will not overwrite an existing user's `display_name` / `avatar_url` with `null` on a re-login where the Steam profile fetch failed — preserves previously-good data through transient outages.
- `PATCH /auth/me` normalizes blank and whitespace-only strings to `null`, closing the secondary vector called out in the issue.
- Added `_personaname` helper that also rejects the exact `personaname == steam_id` case some accounts surface, since that's the literal symptom reported in the issue.

## Test plan

- [x] `uv run pytest` — 57 passed, 1 skipped
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] New `tests/test_steam_display_name.py` covers:
  - `_personaname` unit cases (blank, whitespace, SteamID64, non-string, short numeric handle preserved)
  - `_get_steam_profile` resilience (no api key, 4xx/5xx, no players, transport error, non-JSON body)
  - `_find_or_create_user` persistence rules (new user keeps `null`, existing user not clobbered on failed re-login, existing user updated on success)
  - End-to-end `/auth/steam/callback` with mocked Steam API for the three key scenarios: `personaname == steam_id`, fetch failure, happy path
  - `PATCH /auth/me` blank-string normalization for `display_name` and `avatar_url`
- [ ] Manual: sign in via Steam against staging once deployed and confirm the persona name appears in the navbar (or email if Steam is down)