### PR TITLE
fix(steam): drop speculative personaname filter, alert on API-key rejection

### DIFF
--- a/app/routers/auth_steam.py
+++ b/app/routers/auth_steam.py
@@ -12,6 +12,7 @@ import re
 from urllib.parse import urlencode
 
 import httpx
+import sentry_sdk
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import RedirectResponse
@@ -165,6 +166,17 @@ async def _get_steam_profile(steam_id: str) -> dict:
 
     if resp.status_code != 200:
         logger.warning("steam.profile_fetch_failed", steam_id=steam_id, status=resp.status_code)
+        # 401/403 mean the API key itself is rejected — revoked, invalid, or
+        # bound to a domain that no longer matches. These are persistent and
+        # need a human to rotate the key; surface loudly via Sentry. 429/5xx
+        # are transient and self-heal on the next request.
+        if resp.status_code in (401, 403):
+            sentry_sdk.capture_message(
+                f"Steam Web API rejected our API key (HTTP {resp.status_code}). "
+                "Rotate the key at https://steamcommunity.com/dev/apikey and "
+                "push it to Secret Manager (auth-steam-api-key).",
+                level="error",
+            )
         return {}
 
     try:
@@ -178,22 +190,14 @@ async def _get_steam_profile(steam_id: str) -> dict:
 def _personaname(profile: dict) -> str | None:
     """Extract a usable persona name from a Steam profile.
 
-    Returns None when:
-    - the profile is empty (GetPlayerSummaries failed or returned no players),
-    - `personaname` is missing or blank after stripping whitespace,
-    - `personaname` is literally the SteamID64 — some accounts default it that
-      way and surfacing a raw 17-digit number is worse than null, since the UI
-      falls back to email.
+    Returns None when the profile is empty (GetPlayerSummaries failed or
+    returned no players) or `personaname` is missing/blank after stripping.
     """
     raw = profile.get("personaname")
     if not isinstance(raw, str):
         return None
     name = raw.strip()
-    if not name:
-        return None
-    if name.isdigit() and len(name) >= 16:
-        return None
-    return name
+    return name or None
 
 
 async def _find_or_create_user(

--- a/tests/test_steam_display_name.py
+++ b/tests/test_steam_display_name.py
@@ -1,15 +1,18 @@
 """Regression tests for Steam OAuth display_name handling.
 
-Locks down the contract from ag-tech-group/criticalbit-auth-api#26: the Steam
-callback must never write a SteamID64 (or a "Steam User <id>" placeholder)
-into `User.display_name`. When `ISteamUser/GetPlayerSummaries` fails or
-returns no usable persona name, `display_name` stays `None` so both frontends
-fall back to email rather than rendering a raw 17-digit number.
+The Steam callback must never write a `"Steam User <id>"` placeholder into
+`User.display_name`. When `ISteamUser/GetPlayerSummaries` fails or returns no
+usable persona name, `display_name` stays `None` so both frontends fall back
+to email rather than rendering a synthetic name.
 
-This file covers both the pure-helper layer (`_personaname`,
-`_get_steam_profile`) and the persistence layer (`_find_or_create_user`),
-plus the PATCH /auth/me normalization path that also could have leaked the
-empty string into the column.
+Also covers the alerting contract: when Steam returns HTTP 401/403 we capture
+a Sentry error so a revoked / domain-mismatched API key surfaces immediately
+instead of silently degrading every login.
+
+This file covers the pure-helper layer (`_personaname`, `_get_steam_profile`),
+the persistence layer (`_find_or_create_user`), and the PATCH /auth/me
+normalization path that also could have leaked the empty string into the
+column.
 """
 
 from __future__ import annotations
@@ -57,14 +60,12 @@ class TestPersonaname:
     def test_whitespace_only_returns_none(self) -> None:
         assert _personaname({"personaname": "   "}) is None
 
-    def test_steamid64_string_returns_none(self) -> None:
-        # The exact regression — Steam returning the SteamID64 as personaname
-        # must not be propagated to display_name.
-        assert _personaname({"personaname": A_STEAM_ID}) is None
-
-    def test_numeric_name_below_steamid_length_is_kept(self) -> None:
-        # Don't be over-eager: a short numeric handle is still a name.
+    def test_numeric_name_is_kept(self) -> None:
+        # User-chosen handles can be all-digits — including long ones that
+        # happen to look SteamID-shaped. We don't second-guess Steam's
+        # response; if the API returned a non-empty personaname, use it.
         assert _personaname({"personaname": "12345"}) == "12345"
+        assert _personaname({"personaname": A_STEAM_ID}) == A_STEAM_ID
 
     def test_non_string_field_returns_none(self) -> None:
         assert _personaname({"personaname": 12345}) is None
@@ -146,6 +147,62 @@ class TestGetSteamProfile:
 
         patch_httpx(handler)
         assert await _get_steam_profile(A_STEAM_ID) == {}
+
+
+# --- Sentry alerts on API-key rejection ---------------------------------
+
+
+class TestSteamApiKeyAlerts:
+    """A revoked or domain-mismatched Steam API key returns 401/403 on every
+    call and silently breaks display_name capture for every user. The 403
+    must be captured in Sentry as an error so it pages a human, while
+    transient 429/5xx must NOT — they self-heal on the next request and
+    would just create alert fatigue.
+    """
+
+    @pytest.fixture
+    def capture_sentry(self, monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+        captured: list[dict] = []
+
+        def _capture(message: str, level: str = "info", **kwargs) -> None:
+            captured.append({"message": message, "level": level, **kwargs})
+
+        monkeypatch.setattr(auth_steam.sentry_sdk, "capture_message", _capture)
+        return captured
+
+    @pytest.mark.parametrize("status", [401, 403])
+    async def test_captures_sentry_error_on_key_rejection(
+        self, status, steam_api_key, patch_httpx, capture_sentry
+    ) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(status, text="forbidden")
+
+        patch_httpx(handler)
+        assert await _get_steam_profile(A_STEAM_ID) == {}
+        assert len(capture_sentry) == 1
+        assert capture_sentry[0]["level"] == "error"
+        assert str(status) in capture_sentry[0]["message"]
+
+    @pytest.mark.parametrize("status", [429, 500, 502, 503])
+    async def test_does_not_capture_on_transient_failure(
+        self, status, steam_api_key, patch_httpx, capture_sentry
+    ) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(status, text="transient")
+
+        patch_httpx(handler)
+        assert await _get_steam_profile(A_STEAM_ID) == {}
+        assert capture_sentry == []
+
+    async def test_does_not_capture_on_transport_error(
+        self, steam_api_key, patch_httpx, capture_sentry
+    ) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("boom", request=request)
+
+        patch_httpx(handler)
+        assert await _get_steam_profile(A_STEAM_ID) == {}
+        assert capture_sentry == []
 
 
 # --- _find_or_create_user -----------------------------------------------
@@ -264,36 +321,6 @@ class TestSteamCallbackEndToEnd:
             return A_STEAM_ID
 
         monkeypatch.setattr(auth_steam, "_verify_openid_assertion", _ok)
-
-    async def test_callback_persists_null_when_personaname_is_steamid(
-        self,
-        client: AsyncClient,
-        session: AsyncSession,
-        stub_openid,
-        steam_api_key,
-        patch_httpx,
-    ) -> None:
-        # Steam returns the SteamID64 as personaname (the bug scenario).
-        def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(
-                200,
-                json={"response": {"players": [{"personaname": A_STEAM_ID, "avatarfull": ""}]}},
-            )
-
-        patch_httpx(handler)
-
-        resp = await client.get("/auth/steam/callback", follow_redirects=False)
-        assert resp.status_code == 302, resp.text
-
-        users = (
-            (await session.execute(select(User).where(User.email.like("steam_%"))))
-            .unique()
-            .scalars()
-            .all()
-        )
-        assert len(users) == 1, users
-        assert users[0].display_name is None
-        assert users[0].avatar_url is None
 
     async def test_callback_persists_null_when_profile_fetch_fails(
         self,


### PR DESCRIPTION
## Background

A diagnostic session today traced this morning's "Steam ID instead of username" report back to **HTTP 403 from `ISteamUser/GetPlayerSummaries`** — every Steam login for the last 3+ days has been hitting a revoked API key. Cloud Run logs (3 entries on 2026-05-23, 1 on 2026-05-24) all show `steam.profile_fetch_failed status=403`. Rotating `auth-steam-api-key` in Secret Manager and rolling the Cloud Run revision restored Steam login.

The user's stale `display_name = "Steam User <id>"` traces back to the **old** fallback (`f"Steam User {steam_id}"`) from a much earlier failed call; the new `if display_name:` guard then preserved it indefinitely. Re-login after the key rotation overwrites it correctly.

## What's in this PR

This isn't a fix for the bug itself (the bug was operational — a dead API key). It cleans up two related issues that the diagnosis surfaced:

### 1. Drop the speculative `_personaname` filter

PR #26 added a rejection for `personaname` values that are 16+ digit numeric strings, on the hypothesis that Steam was returning the SteamID64 as personaname. That hypothesis was wrong — Steam was returning **403**, so `_personaname` never even saw a Steam-returned value. The filter is solving a problem that doesn't exist and risks rejecting legitimate user-chosen numeric handles.

### 2. Add Sentry capture on 401/403 from Steam

The 403s were logged at `warning` level via structlog and sat unnoticed in Cloud Logging for days. The fix: explicit `sentry_sdk.capture_message(level='error')` when Steam returns 401 or 403. Those status codes are non-transient and always mean "human needs to rotate the key" — they earn an error-level alert. 429/5xx and transport errors are transient and intentionally skipped to keep the signal clean.

The alert message includes the rotation URL and the Secret Manager secret name so whoever sees it in Sentry can act immediately:

> Steam Web API rejected our API key (HTTP 403). Rotate the key at https://steamcommunity.com/dev/apikey and push it to Secret Manager (auth-steam-api-key).

## Test plan

- [x] `uv run pytest tests/test_steam_display_name.py -v` — 31 passed (existing 23 + 8 new parametrized cases for the Sentry alert)
- [x] `uv run pytest` — full suite, 62 passed / 1 skipped (pre-existing)
- [x] `uv run ruff check app tests` + `uv run ruff format --check app tests` — clean
- [x] Manual: confirmed in production that re-login after key rotation correctly captures the real `personaname` and overwrites the stale `"Steam User <id>"` value
- [ ] After merge: trigger a test 403 (e.g., temporarily set an invalid key in a staging revision) to confirm the Sentry event fires with the expected message and level

## What's intentionally not in this PR

- **The httpx error-handling, blank-string normalization, and re-login-don't-clobber logic from #26 — those all stay.** They have real defensive value independent of the dead-key root cause (Steam outages are real, blank inputs happen, transient failures shouldn't wipe good data).
- **No data migration to clean up other users in the "Steam User <id>" state.** Every such user will get their `display_name` overwritten on next Steam re-login now that the API works. If we want active backfill (e.g., for users who don't log in often), that's a separate one-shot script.