### PR TITLE
chore(deploy): pin SENTRY_DSN binding and set SENTRY_RELEASE per deploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,10 +46,12 @@ LOG_LEVEL=INFO
 
 # Sentry error tracking
 # Leave SENTRY_DSN unset in dev to skip Sentry initialization entirely.
-# In production it's set as a Cloud Run environment variable.
+# In production it's bound from Secret Manager (auth-sentry-dsn) via the
+# Cloud Run service config, set up by .github/workflows/deploy.yml.
 SENTRY_DSN=
 
-# Optional release tag so Sentry can group events by deploy. Leave unset in dev.
+# Release tag so Sentry can group events by deploy. Leave unset in dev;
+# production sets it to the commit SHA via the deploy workflow.
 SENTRY_RELEASE=
 
 # OpenTelemetry (disabled by default)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,9 +59,19 @@ jobs:
             --project ${{ env.GCP_PROJECT }} \
             --wait
 
+      # SENTRY_DSN is bound from Secret Manager (auth-sentry-dsn:latest) and
+      # SENTRY_RELEASE is set to the commit SHA so Sentry can group errors,
+      # transactions, and profiles by deploy. The secret binding survives
+      # `services update --image` automatically, but listing it here makes the
+      # production env contract explicit in version control.
       - name: Deploy to Cloud Run
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          IMAGE_TAG: ${{ env.IMAGE }}:${{ github.sha }}
         run: |
-          gcloud run services update ${{ env.SERVICE_NAME }} \
-            --image ${{ env.IMAGE }}:${{ github.sha }} \
-            --region ${{ env.GCP_REGION }} \
-            --project ${{ env.GCP_PROJECT }}
+          gcloud run services update "${{ env.SERVICE_NAME }}" \
+            --image "$IMAGE_TAG" \
+            --region "${{ env.GCP_REGION }}" \
+            --project "${{ env.GCP_PROJECT }}" \
+            --update-secrets=SENTRY_DSN=auth-sentry-dsn:latest \
+            --update-env-vars="SENTRY_RELEASE=$COMMIT_SHA"


### PR DESCRIPTION
## Why

Diagnosing today's Steam display_name bug surfaced that `SENTRY_DSN` was never bound on the Cloud Run service — the Sentry SDK had been initializing as a no-op in production since PR #22 shipped. Fixed manually today by creating Secret Manager secret \`auth-sentry-dsn\` and binding it via \`gcloud run services update --update-secrets\`. Logs from the criticalbit-auth-api Sentry project confirm events are now flowing.

This PR makes that wiring durable across future deploys.

## What

- **\`deploy.yml\`**: Add \`--update-secrets=SENTRY_DSN=auth-sentry-dsn:latest\` and \`--update-env-vars=SENTRY_RELEASE=$COMMIT_SHA\` to the Cloud Run service update step. The secret binding already survives \`services update --image\` automatically, but listing it in the workflow makes the production env contract reviewable in git and prevents drift if anyone runs \`--clear-secrets\` elsewhere.
- **\`deploy.yml\`**: Switch the gcloud command to use env-injected variables instead of \`\${{ github.sha }}\` inline interpolation. \`github.sha\` is trusted (40-char hex), but the env-var pattern is best practice and consistent if more inputs are added later.
- **\`.env.example\`**: Update the SENTRY_DSN and SENTRY_RELEASE comments to point at Secret Manager and the deploy workflow as the source of truth, instead of the vague "Cloud Run environment variable" claim.

## Verification (already done manually)

- ✅ Secret \`auth-sentry-dsn\` v1 created in \`criticalbit-production\` Secret Manager
- ✅ Cloud Run SA \`criticalbit-auth-api-sa\` granted \`roles/secretmanager.secretAccessor\`
- ✅ Revision \`criticalbit-auth-api-00015-75z\` is live with SENTRY_DSN bound
- ✅ INFO logs flowing to the criticalbit-auth-api Sentry project (verified via the Sentry MCP)

## Known follow-up (separate PR)

Transactions/spans are not appearing in Sentry despite 100+ \`/health\` requests at a 10% sample rate. Logs work, errors capture should work (uses the same transport), but the FastAPI tracing integration isn't producing transaction events. Tracking and investigating in a follow-up PR.

## Test plan

- [ ] After merge, observe the next deploy in GitHub Actions and confirm the new revision still serves \`/health\` 200 OK
- [ ] Confirm the new revision's env vars include both \`SENTRY_DSN\` (secret) and \`SENTRY_RELEASE\` (inline = SHA)
- [ ] Confirm logs continue arriving in the criticalbit-auth-api Sentry project tagged with the SHA as release