### PR TITLE
feat(users): add GET /users/search type-ahead endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -21,7 +21,7 @@ from app.database import get_async_session
 from app.features import router as features_router
 from app.logging import setup_logging
 from app.models.user import User
-from app.routers import admin_router, user_consent_router
+from app.routers import admin_router, user_consent_router, users_router
 from app.routers.auth_refresh import router as auth_refresh_router
 from app.schemas.user import UserCreate, UserRead
 from app.sentry import init_sentry
@@ -221,19 +221,21 @@ async def delete_current_user(
     await session.commit()
 
 
-# Path-specific rate limits for auth endpoints
+# Path-specific rate limits, keyed by "METHOD /path".
 _AUTH_RATE_LIMITS: dict[str, RateLimitItem] = {
-    "/auth/jwt/login": parse("5/minute"),
-    "/auth/register": parse("3/minute"),
-    "/auth/refresh": parse("30/minute"),
+    "POST /auth/jwt/login": parse("5/minute"),
+    "POST /auth/register": parse("3/minute"),
+    "POST /auth/refresh": parse("30/minute"),
+    # /users/search is auth-bearing but enumeration-adjacent, so cap it.
+    "GET /users/search": parse("60/minute"),
 }
 
 
 @app.middleware("http")
 async def rate_limit_auth(request: Request, call_next) -> Response:
-    """Apply rate limits to auth endpoints."""
-    rate_limit = _AUTH_RATE_LIMITS.get(request.url.path)
-    if rate_limit and request.method == "POST":
+    """Apply rate limits to auth and enumeration-adjacent endpoints."""
+    rate_limit = _AUTH_RATE_LIMITS.get(f"{request.method} {request.url.path}")
+    if rate_limit:
         key = get_remote_address(request)
         if not limiter._limiter.hit(rate_limit, key):
             log_security_event(
@@ -291,6 +293,7 @@ async def request_logging_middleware(request: Request, call_next) -> Response:
 # API routes
 app.include_router(admin_router)
 app.include_router(user_consent_router)
+app.include_router(users_router)
 app.include_router(features_router)
 
 

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,4 +1,5 @@
 from app.routers.admin import router as admin_router
 from app.routers.user_consent import router as user_consent_router
+from app.routers.users import router as users_router
 
-__all__ = ["admin_router", "user_consent_router"]
+__all__ = ["admin_router", "user_consent_router", "users_router"]

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -1,0 +1,80 @@
+"""User lookup endpoints.
+
+Currently exposes a single type-ahead search used by consumer apps that need
+a user picker (e.g. the standings admin tab choosing who to grant ownership
+to). Match keys include email for admin convenience, but email is never in
+the response payload — see :class:`UserSearchResult`.
+"""
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import case, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import current_active_user
+from app.database import get_async_session
+from app.models.user import User
+from app.schemas.user import UserSearchResult
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+MAX_SEARCH_LIMIT = 50
+DEFAULT_SEARCH_LIMIT = 10
+
+
+def _escape_like(value: str) -> str:
+    """Escape LIKE wildcards so user input matches literally."""
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+@router.get("/search", response_model=list[UserSearchResult])
+async def search_users(
+    q: str = Query("", description="Substring matched against display_name or email."),
+    limit: int = Query(DEFAULT_SEARCH_LIMIT, ge=1, le=MAX_SEARCH_LIMIT),
+    _user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_async_session),
+) -> list[UserSearchResult]:
+    """Type-ahead user picker for consumer apps.
+
+    Matches `q` (case-insensitive substring) against display_name AND email.
+    Email is accepted as an input match-key for admin convenience but is
+    never returned — that's why the response schema has no email field.
+    """
+    q = q.strip()
+    if not q:
+        return []
+
+    escaped = _escape_like(q)
+    substring = f"%{escaped}%"
+    prefix = f"{escaped}%"
+
+    # Prefix matches on display_name sort ahead of pure substring matches.
+    # Null display_name sorts last so a hit only via email doesn't outrank
+    # a hit with a real name to show.
+    prefix_rank = case((User.display_name.ilike(prefix, escape="\\"), 0), else_=1)
+
+    stmt = (
+        select(User)
+        .where(
+            or_(
+                User.display_name.ilike(substring, escape="\\"),
+                User.email.ilike(substring, escape="\\"),
+            )
+        )
+        .order_by(
+            prefix_rank,
+            User.display_name.is_(None),
+            User.display_name,
+            User.email,
+        )
+        .limit(limit)
+    )
+    result = await session.execute(stmt)
+    users = result.unique().scalars().all()
+    return [
+        UserSearchResult(
+            id=user.id,
+            display_name=user.display_name,
+            avatar_url=user.avatar_url,
+        )
+        for user in users
+    ]

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from uuid import UUID
 
 from fastapi_users import schemas
+from pydantic import BaseModel
 
 
 class UserRead(schemas.BaseUser[UUID]):
@@ -24,3 +25,15 @@ class UserUpdate(schemas.BaseUserUpdate):
     """Schema for updating user data."""
 
     pass
+
+
+class UserSearchResult(BaseModel):
+    """Public projection returned by /users/search.
+
+    Deliberately omits email — the endpoint accepts email as a match-key but
+    never surfaces it. PII stays server-side.
+    """
+
+    id: UUID
+    display_name: str | None = None
+    avatar_url: str | None = None

--- a/tests/test_users_search.py
+++ b/tests/test_users_search.py
@@ -1,0 +1,229 @@
+"""Tests for GET /users/search.
+
+Covers the public contract from issue #30:
+- Auth required (401 anonymous).
+- Empty query returns [] (not 422).
+- Matches against display_name AND email (substring, case-insensitive).
+- Email is never present in the response payload.
+- limit param defaults to 10 and is capped server-side.
+- Prefix matches on display_name rank ahead of pure substring hits.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user import User
+
+
+@pytest.fixture
+async def seeded(session: AsyncSession) -> list[User]:
+    """Seed a small set with predictable shapes for matching tests.
+
+    Naming chosen so a single query ("ali") exercises the three match paths:
+    - Alice → prefix match on display_name.
+    - Bob the Alibi → substring match on display_name.
+    - alimony → email-only match (display_name is null).
+    """
+    users = [
+        User(
+            id=uuid4(),
+            email="alice@example.com",
+            hashed_password="x",
+            display_name="Alice",
+            avatar_url="https://example.com/alice.png",
+        ),
+        User(
+            id=uuid4(),
+            email="alex@example.com",
+            hashed_password="x",
+            display_name="Alex",
+            avatar_url=None,
+        ),
+        User(
+            id=uuid4(),
+            email="bob@example.com",
+            hashed_password="x",
+            display_name="Bob the Alibi",
+            avatar_url=None,
+        ),
+        User(
+            id=uuid4(),
+            email="alimony@example.com",
+            hashed_password="x",
+            display_name=None,
+            avatar_url=None,
+        ),
+        User(
+            # Synthetic Steam-style email — should match an "@users.criticalbit"
+            # query as substring, but the email must NOT come back in the body.
+            id=uuid4(),
+            email="steam_76561198000000099@users.criticalbit.gg",
+            hashed_password="!steam-oauth-no-password",
+            display_name="GabeStreams",
+            avatar_url="https://example.com/gabe.png",
+        ),
+    ]
+    for u in users:
+        session.add(u)
+    await session.commit()
+    return users
+
+
+# --- 401 anonymous ----------------------------------------------------------
+
+
+async def test_anonymous_returns_401(client: AsyncClient) -> None:
+    resp = await client.get("/users/search?q=alice")
+    assert resp.status_code == 401, resp.text
+
+
+# --- empty query -----------------------------------------------------------
+
+
+async def test_empty_query_returns_empty_array(auth_client: AsyncClient) -> None:
+    resp = await auth_client.get("/users/search?q=")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_missing_query_returns_empty_array(auth_client: AsyncClient) -> None:
+    resp = await auth_client.get("/users/search")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_whitespace_only_query_returns_empty_array(auth_client: AsyncClient) -> None:
+    resp = await auth_client.get("/users/search?q=%20%20%20")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+# --- display_name and email matching ---------------------------------------
+
+
+async def test_matches_display_name_substring(auth_client: AsyncClient, seeded: list[User]) -> None:
+    resp = await auth_client.get("/users/search?q=ali")
+    assert resp.status_code == 200
+    names = {row["display_name"] for row in resp.json()}
+    # Alice (prefix on display), Bob the Alibi (substring "Ali" on display),
+    # and alimony (None display, matched via email "alimony@…").
+    # Alex must NOT appear: "ali" is not in "alex".
+    assert {"Alice", "Bob the Alibi", None} == names
+
+
+async def test_matches_email_substring(auth_client: AsyncClient, seeded: list[User]) -> None:
+    # "alimony" only matches via email; display_name is null.
+    resp = await auth_client.get("/users/search?q=alimony")
+    body = resp.json()
+    assert resp.status_code == 200
+    assert len(body) == 1
+    assert body[0]["display_name"] is None
+
+
+async def test_match_is_case_insensitive(auth_client: AsyncClient, seeded: list[User]) -> None:
+    resp = await auth_client.get("/users/search?q=ALICE")
+    body = resp.json()
+    assert resp.status_code == 200
+    assert any(row["display_name"] == "Alice" for row in body)
+
+
+# --- response shape: never includes email ----------------------------------
+
+
+async def test_email_is_never_in_response(auth_client: AsyncClient, seeded: list[User]) -> None:
+    resp = await auth_client.get("/users/search?q=alice")
+    body = resp.json()
+    assert resp.status_code == 200
+    assert body, "expected matches"
+    for row in body:
+        assert "email" not in row, f"email leaked into response: {row}"
+        assert set(row.keys()) <= {"id", "display_name", "avatar_url"}
+
+
+async def test_synthetic_steam_email_matches_but_not_returned(
+    auth_client: AsyncClient, seeded: list[User]
+) -> None:
+    # Querying for the synthetic-email suffix should still find the Steam user.
+    resp = await auth_client.get("/users/search?q=users.criticalbit")
+    body = resp.json()
+    assert resp.status_code == 200
+    assert any(row["display_name"] == "GabeStreams" for row in body)
+    # And the synthetic email is not echoed back.
+    for row in body:
+        assert "email" not in row
+
+
+# --- limit -----------------------------------------------------------------
+
+
+async def test_limit_param_caps_results(auth_client: AsyncClient, seeded: list[User]) -> None:
+    resp = await auth_client.get("/users/search?q=a&limit=2")
+    body = resp.json()
+    assert resp.status_code == 200
+    assert len(body) == 2
+
+
+async def test_limit_above_cap_returns_422(auth_client: AsyncClient, seeded: list[User]) -> None:
+    resp = await auth_client.get("/users/search?q=a&limit=1000")
+    # Pydantic enforces the upper bound; out-of-range is a validation error.
+    assert resp.status_code == 422, resp.text
+
+
+async def test_limit_below_one_returns_422(auth_client: AsyncClient) -> None:
+    resp = await auth_client.get("/users/search?q=a&limit=0")
+    assert resp.status_code == 422, resp.text
+
+
+# --- ordering: prefix matches first ----------------------------------------
+
+
+async def test_prefix_matches_rank_before_substring(
+    auth_client: AsyncClient, seeded: list[User]
+) -> None:
+    resp = await auth_client.get("/users/search?q=ali")
+    body = resp.json()
+    assert resp.status_code == 200
+    # Alice prefix-matches display_name; "Bob the Alibi" is a mid-string
+    # match. The prefix hit must come before the substring hit.
+    display_order = [row["display_name"] for row in body]
+    alice_idx = display_order.index("Alice")
+    alibi_idx = display_order.index("Bob the Alibi")
+    assert alice_idx < alibi_idx
+
+
+# --- LIKE wildcard escaping ------------------------------------------------
+
+
+async def test_underscore_in_query_is_treated_literally(
+    auth_client: AsyncClient, seeded: list[User]
+) -> None:
+    # If LIKE wildcards leaked through, "_" would match any single character
+    # and a query of "a_ice" would match "Alice". With escaping, it shouldn't.
+    resp = await auth_client.get("/users/search?q=a_ice")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_percent_in_query_is_treated_literally(
+    auth_client: AsyncClient, seeded: list[User]
+) -> None:
+    # Bare "%" with wildcards leaking would return everyone; escaped, it
+    # should only match an actual literal "%", which we never insert.
+    resp = await auth_client.get("/users/search?q=%25")  # %25 = "%"
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+# --- avatar_url comes through ----------------------------------------------
+
+
+async def test_avatar_url_is_returned(auth_client: AsyncClient, seeded: list[User]) -> None:
+    resp = await auth_client.get("/users/search?q=alice")
+    body = resp.json()
+    alice = next(row for row in body if row["display_name"] == "Alice")
+    assert alice["avatar_url"] == "https://example.com/alice.png"


### PR DESCRIPTION
## Summary

- New `GET /users/search?q=<substring>&limit=10` endpoint matches against `display_name` AND `email` (case-insensitive substring), returning `id`, `display_name`, `avatar_url`. **Email is never in the response** — the `UserSearchResult` schema deliberately omits it so a future bug can't leak PII; email is only an input match-key (admin convenience).
- Prefix matches on `display_name` rank ahead of pure substring hits; null `display_name` sorts last (so an email-only hit doesn't outrank a hit with a real name to render).
- 401 for anonymous callers; rate-limited at 60/min/IP. The existing `_AUTH_RATE_LIMITS` table now keys on `"METHOD /path"` so non-POST endpoints can be capped too.
- LIKE wildcards (`%`, `_`, `\\`) in user input are escaped so a query like `50%_off` matches literally.
- Empty / whitespace-only / missing `q` returns `[]` (not 422). `limit` is bounded to `1..50` by Pydantic.

Closes #30.

## Test plan

- [x] `uv run pytest tests/test_users_search.py` — 16 tests cover 401, empty-q, display/email matching, case-insensitivity, response shape (no email), synthetic Steam email matches via email but isn't returned, limit bounds (default + cap + below-min), prefix-first ordering, LIKE escaping, avatar passthrough.
- [x] Full suite: `uv run pytest` — 78 passed, 1 skipped.
- [x] `uv run ruff check` + `uv run ruff format --check` — clean.
- [ ] Manual smoke against dev server: `curl -b cookies.txt 'http://localhost:8000/users/search?q=ali'`.