### PR TITLE
feat(steam): collect real email from Steam users via accept-tos gate

### DIFF
--- a/app/auth/steam_email.py
+++ b/app/auth/steam_email.py
@@ -1,0 +1,34 @@
+"""Synthetic Steam email helpers.
+
+Steam OpenID doesn't expose user emails, so users created via the Steam flow
+get a synthetic placeholder of the form `steam_<steamid>@users.criticalbit.gg`.
+This is technically valid storage but unusable for notifications, recovery,
+or identification in admin UIs. The accept-tos gate (issue #31) collects a
+real address from these users; the helpers below let callers detect and
+construct the placeholder consistently.
+"""
+
+STEAM_SYNTHETIC_EMAIL_PREFIX = "steam_"
+STEAM_SYNTHETIC_EMAIL_DOMAIN = "users.criticalbit.gg"
+_STEAM_SYNTHETIC_EMAIL_SUFFIX = f"@{STEAM_SYNTHETIC_EMAIL_DOMAIN}"
+
+
+def synthetic_steam_email(steam_id: str) -> str:
+    """Build the placeholder email for a Steam user."""
+    return f"{STEAM_SYNTHETIC_EMAIL_PREFIX}{steam_id}{_STEAM_SYNTHETIC_EMAIL_SUFFIX}"
+
+
+def is_synthetic_steam_email(email: str | None) -> bool:
+    """Return True iff `email` looks like a Steam synthetic placeholder.
+
+    The check is `steam_…@users.criticalbit.gg` (case-insensitive). A
+    legitimate human address that happens to be on the
+    `@users.criticalbit.gg` domain — none currently exist, but the guard is
+    cheap — is correctly classified as not synthetic.
+    """
+    if not email:
+        return False
+    lowered = email.lower()
+    return lowered.startswith(STEAM_SYNTHETIC_EMAIL_PREFIX) and lowered.endswith(
+        _STEAM_SYNTHETIC_EMAIL_SUFFIX
+    )

--- a/app/auth/users.py
+++ b/app/auth/users.py
@@ -15,7 +15,7 @@ from app.auth.refresh import create_refresh_token, set_refresh_cookie
 from app.auth.security_logging import SecurityEvent, log_security_event
 from app.config import settings
 from app.database import async_session_maker, get_async_session
-from app.email import send_reset_password_email
+from app.email import send_reset_password_email, send_verification_email
 from app.models.oauth_account import OAuthAccount
 from app.models.user import User
 
@@ -137,7 +137,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, UUID]):
         send_reset_password_email(user.email, token)
 
     async def on_after_request_verify(self, user: User, token: str, request=None):
-        logger.info("Email verification requested for user %s.", user.id)
+        send_verification_email(user.email, token)
 
 
 async def get_user_manager(

--- a/app/email.py
+++ b/app/email.py
@@ -47,3 +47,35 @@ def send_reset_password_email(email: str, token: str) -> None:
         logger.info("email.sent", to=email, type="reset_password")
     except Exception:
         logger.exception("email.failed", to=email, type="reset_password")
+
+
+def send_verification_email(email: str, token: str) -> None:
+    """Send a verification email with a link containing the verify token."""
+    verify_url = f"{settings.frontend_url}/verify-email?token={token}"
+
+    if not _email_enabled:
+        logger.warning(
+            "email.skipped",
+            reason="RESEND_API_KEY not set",
+            to=email,
+            verify_url=verify_url,
+        )
+        return
+
+    try:
+        resend.Emails.send(
+            {
+                "from": settings.email_from,
+                "to": email,
+                "subject": "Verify your criticalbit.gg email",
+                "html": f"""
+                    <h2>Verify your email</h2>
+                    <p>Click the link below to confirm this address. This link expires in 1 hour.</p>
+                    <p><a href="{verify_url}">Verify email</a></p>
+                    <p>If you didn't request this, you can safely ignore this email.</p>
+                """,
+            }
+        )
+        logger.info("email.sent", to=email, type="verification")
+    except Exception:
+        logger.exception("email.failed", to=email, type="verification")

--- a/app/main.py
+++ b/app/main.py
@@ -1,13 +1,14 @@
 import time
 import uuid
 
+import sqlalchemy as sa
 import structlog
-from fastapi import Depends, FastAPI, Request, Response
+from fastapi import Body, Depends, FastAPI, HTTPException, Request, Response, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, RedirectResponse
 from httpx_oauth.clients.google import GoogleOAuth2
 from limits import RateLimitItem, parse
-from pydantic import BaseModel
+from pydantic import BaseModel, EmailStr
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
@@ -16,6 +17,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth import auth_backend, current_active_user, fastapi_users
 from app.auth.keys import get_jwks
 from app.auth.security_logging import SecurityEvent, log_security_event
+from app.auth.steam_email import is_synthetic_steam_email
+from app.auth.users import UserManager, get_user_manager
 from app.config import settings
 from app.database import get_async_session
 from app.features import router as features_router
@@ -69,6 +72,11 @@ app.include_router(
 )
 app.include_router(
     fastapi_users.get_reset_password_router(),
+    prefix="/auth",
+    tags=["auth"],
+)
+app.include_router(
+    fastapi_users.get_verify_router(UserRead),
     prefix="/auth",
     tags=["auth"],
 )
@@ -190,19 +198,89 @@ async def update_current_user(
 CURRENT_TOS_VERSION = "2026-03-16"
 
 
+class AcceptTosRequest(BaseModel):
+    """Body for POST /auth/accept-tos.
+
+    `email` is only required for Steam users still carrying the synthetic
+    `steam_…@users.criticalbit.gg` placeholder — see issue #31. Other users
+    can omit the body entirely.
+    """
+
+    email: EmailStr | None = None
+
+
 @app.post("/auth/accept-tos", response_model=UserRead, tags=["auth"])
 async def accept_tos(
+    body: AcceptTosRequest = Body(default_factory=AcceptTosRequest),
     user: User = Depends(current_active_user),
     session: AsyncSession = Depends(get_async_session),
+    user_manager: UserManager = Depends(get_user_manager),
 ):
-    """Record the user's acceptance of the current Terms of Service."""
+    """Record the user's acceptance of the current Terms of Service.
+
+    For Steam users whose email is still the synthetic placeholder, this
+    endpoint doubles as the email-collection gate: an `email` must be
+    supplied, replaces the placeholder, resets `is_verified`, and triggers
+    a verification email (non-blocking). See issue #31.
+    """
     from datetime import UTC, datetime
+
+    replaced_synthetic_email = False
+    if is_synthetic_steam_email(user.email):
+        if not body.email:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail={
+                    "code": "email_required",
+                    "message": "An email address is required to finish setting up your account.",
+                },
+            )
+        new_email = body.email.strip().lower()
+        if is_synthetic_steam_email(new_email):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail={
+                    "code": "email_invalid",
+                    "message": "Please provide a real email address.",
+                },
+            )
+        # Collision check — case-insensitive to match how we store/compare.
+        collision = await session.execute(
+            sa.select(User).where(
+                sa.func.lower(User.email) == new_email,
+                User.id != user.id,
+            )
+        )
+        if collision.unique().scalar_one_or_none() is not None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail={
+                    "code": "email_already_registered",
+                    "message": (
+                        "An account with that email already exists. Sign in to that "
+                        "account and link Steam from your profile."
+                    ),
+                },
+            )
+
+        user.email = new_email
+        user.is_verified = False
+        replaced_synthetic_email = True
 
     user.tos_accepted_at = datetime.now(UTC)
     user.tos_version = CURRENT_TOS_VERSION
     session.add(user)
     await session.commit()
     await session.refresh(user)
+
+    if replaced_synthetic_email:
+        # Non-blocking: if the verification dispatch fails the user can still
+        # use the platform; they'll get a fresh chance via /auth/request-verify-token.
+        try:
+            await user_manager.request_verify(user)
+        except Exception:
+            logger.exception("verification.dispatch_failed", user_id=str(user.id))
+
     return user
 
 

--- a/app/routers/auth_steam.py
+++ b/app/routers/auth_steam.py
@@ -22,6 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth.backend import get_jwt_strategy
 from app.auth.refresh import create_refresh_token, set_refresh_cookie
 from app.auth.security_logging import SecurityEvent, log_security_event
+from app.auth.steam_email import synthetic_steam_email
 from app.config import settings
 from app.database import get_async_session
 from app.models.oauth_account import OAuthAccount
@@ -234,7 +235,7 @@ async def _find_or_create_user(
 
     # Create a new user with a placeholder email (Steam doesn't provide emails)
     # The email is a non-deliverable placeholder — user can update it later
-    placeholder_email = f"steam_{steam_id}@users.criticalbit.gg"
+    placeholder_email = synthetic_steam_email(steam_id)
 
     user = User(
         email=placeholder_email,

--- a/tests/test_accept_tos_email_gate.py
+++ b/tests/test_accept_tos_email_gate.py
@@ -1,0 +1,281 @@
+"""Tests for the Steam email-collection gate on POST /auth/accept-tos.
+
+Covers issue #31:
+- Synthetic-email detection helper.
+- Steam users with synthetic email must supply a real email.
+- Supplied email must not itself be a synthetic placeholder.
+- Collision with an existing account returns a structured 422.
+- Successful submission overwrites the email, resets is_verified, and
+  dispatches a verification email (non-blocking).
+- Non-synthetic users still accept TOS without supplying an email.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import users as users_module
+from app.auth.steam_email import (
+    is_synthetic_steam_email,
+    synthetic_steam_email,
+)
+from app.main import app
+from app.models.user import User
+
+A_STEAM_ID = "76561198000000042"
+
+
+# --- Synthetic email helper ------------------------------------------------
+
+
+class TestIsSyntheticSteamEmail:
+    def test_canonical_synthetic_is_detected(self) -> None:
+        assert is_synthetic_steam_email(synthetic_steam_email(A_STEAM_ID))
+
+    def test_case_insensitive(self) -> None:
+        assert is_synthetic_steam_email(f"STEAM_{A_STEAM_ID}@USERS.CRITICALBIT.GG")
+
+    def test_human_email_not_detected(self) -> None:
+        assert not is_synthetic_steam_email("alice@example.com")
+
+    def test_steam_prefix_alone_not_detected(self) -> None:
+        # Wrong domain.
+        assert not is_synthetic_steam_email("steam_123@example.com")
+
+    def test_users_domain_alone_not_detected(self) -> None:
+        # Right domain but no steam_ prefix — would be a hypothetical real
+        # user on that domain, not a synthetic placeholder.
+        assert not is_synthetic_steam_email("alice@users.criticalbit.gg")
+
+    def test_none_returns_false(self) -> None:
+        assert not is_synthetic_steam_email(None)
+
+    def test_empty_returns_false(self) -> None:
+        assert not is_synthetic_steam_email("")
+
+
+# --- accept-tos behavior ---------------------------------------------------
+
+
+@pytest.fixture
+def steam_user() -> User:
+    """A user who came in via Steam OpenID — still on the placeholder email."""
+    return User(
+        id=uuid4(),
+        email=synthetic_steam_email(A_STEAM_ID),
+        hashed_password="!steam-oauth-no-password",
+        is_active=True,
+        is_verified=False,
+    )
+
+
+@pytest.fixture
+async def auth_as_steam(client: AsyncClient, steam_user: User):
+    """Authenticate as a Steam-style user without pre-attaching to a session.
+
+    The route handler owns its own session via Depends(get_async_session); if
+    we eagerly attach `steam_user` to the test-setup session SQLAlchemy will
+    refuse to let the handler's session re-add it.
+    """
+    from app.auth import current_active_user
+
+    app.dependency_overrides[current_active_user] = lambda: steam_user
+    try:
+        yield client
+    finally:
+        app.dependency_overrides.pop(current_active_user, None)
+
+
+@pytest.fixture
+def captured_verification_emails(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+    """Capture send_verification_email calls without hitting Resend."""
+    captured: list[dict] = []
+
+    def _capture(email: str, token: str) -> None:
+        captured.append({"email": email, "token": token})
+
+    monkeypatch.setattr(users_module, "send_verification_email", _capture)
+    return captured
+
+
+# --- non-synthetic users keep the old behavior -----------------------------
+
+
+async def test_non_steam_user_accepts_tos_without_email(
+    auth_client: AsyncClient, test_user: User
+) -> None:
+    # test_user has email "test@example.com" — not synthetic.
+    resp = await auth_client.post("/auth/accept-tos")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["tos_accepted_at"] is not None
+    assert body["tos_version"]
+
+
+async def test_non_steam_user_accepts_tos_with_empty_body(auth_client: AsyncClient) -> None:
+    resp = await auth_client.post("/auth/accept-tos", json={})
+    assert resp.status_code == 200, resp.text
+
+
+# --- synthetic users: email required ---------------------------------------
+
+
+async def test_steam_user_without_email_is_rejected(
+    auth_as_steam: AsyncClient,
+) -> None:
+    resp = await auth_as_steam.post("/auth/accept-tos", json={})
+    assert resp.status_code == 422, resp.text
+    detail = resp.json()["detail"]
+    assert detail["code"] == "email_required"
+
+
+async def test_steam_user_with_synthetic_email_is_rejected(
+    auth_as_steam: AsyncClient,
+) -> None:
+    # Trying to satisfy the gate by re-submitting the placeholder must fail.
+    resp = await auth_as_steam.post(
+        "/auth/accept-tos",
+        json={"email": synthetic_steam_email(A_STEAM_ID)},
+    )
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["detail"]["code"] == "email_invalid"
+
+
+async def test_steam_user_with_other_synthetic_email_is_rejected(
+    auth_as_steam: AsyncClient,
+) -> None:
+    # Even a different steam_id placeholder must be rejected — the suffix
+    # itself is forbidden.
+    resp = await auth_as_steam.post(
+        "/auth/accept-tos",
+        json={"email": "steam_99999999999999999@users.criticalbit.gg"},
+    )
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["detail"]["code"] == "email_invalid"
+
+
+# --- synthetic users: collision -------------------------------------------
+
+
+async def test_email_collision_returns_422(
+    auth_as_steam: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    session.add(
+        User(
+            id=uuid4(),
+            email="taken@example.com",
+            hashed_password="x",
+            is_active=True,
+        )
+    )
+    await session.commit()
+
+    resp = await auth_as_steam.post(
+        "/auth/accept-tos",
+        json={"email": "taken@example.com"},
+    )
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["detail"]["code"] == "email_already_registered"
+
+
+async def test_email_collision_is_case_insensitive(
+    auth_as_steam: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    session.add(
+        User(
+            id=uuid4(),
+            email="taken@example.com",
+            hashed_password="x",
+            is_active=True,
+        )
+    )
+    await session.commit()
+
+    resp = await auth_as_steam.post(
+        "/auth/accept-tos",
+        json={"email": "Taken@Example.COM"},
+    )
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["detail"]["code"] == "email_already_registered"
+
+
+# --- happy path -----------------------------------------------------------
+
+
+async def test_successful_submit_replaces_email_and_resets_verification(
+    auth_as_steam: AsyncClient,
+    steam_user: User,
+    session: AsyncSession,
+    captured_verification_emails: list[dict],
+) -> None:
+    # Pre-condition: pretend is_verified was already True so we can prove the
+    # route resets it. Mutate in-memory only — the route's own session will
+    # persist it on commit.
+    steam_user.is_verified = True
+
+    resp = await auth_as_steam.post(
+        "/auth/accept-tos",
+        json={"email": "real@example.com"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["email"] == "real@example.com"
+    assert body["is_verified"] is False
+    assert body["tos_accepted_at"] is not None
+
+    # Persisted.
+    fresh = await session.get(User, steam_user.id)
+    assert fresh is not None
+    assert fresh.email == "real@example.com"
+    assert fresh.is_verified is False
+
+    # Verification email dispatched exactly once, to the new address.
+    assert len(captured_verification_emails) == 1
+    assert captured_verification_emails[0]["email"] == "real@example.com"
+    assert captured_verification_emails[0]["token"]
+
+
+async def test_supplied_email_is_normalized_lowercase(
+    auth_as_steam: AsyncClient,
+    steam_user: User,
+    session: AsyncSession,
+    captured_verification_emails: list[dict],
+) -> None:
+    resp = await auth_as_steam.post(
+        "/auth/accept-tos",
+        json={"email": "  Real@Example.COM  "},
+    )
+    assert resp.status_code == 200, resp.text
+    fresh = await session.get(User, steam_user.id)
+    assert fresh is not None
+    assert fresh.email == "real@example.com"
+
+
+async def test_verification_dispatch_failure_does_not_block_accept(
+    auth_as_steam: AsyncClient,
+    steam_user: User,
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Make the dispatch hook blow up — the request must still succeed,
+    # because verification is explicitly non-blocking.
+    def _boom(email: str, token: str) -> None:
+        raise RuntimeError("resend is down")
+
+    monkeypatch.setattr(users_module, "send_verification_email", _boom)
+
+    resp = await auth_as_steam.post(
+        "/auth/accept-tos",
+        json={"email": "real@example.com"},
+    )
+    assert resp.status_code == 200, resp.text
+    fresh = await session.get(User, steam_user.id)
+    assert fresh is not None
+    assert fresh.email == "real@example.com"
+    assert fresh.is_verified is False


### PR DESCRIPTION
## Summary

Steam OpenID doesn't expose user emails, so Steam logins land users on a synthetic placeholder (`steam_<id>@users.criticalbit.gg`) — fine for storage, useless for notifications, recovery, and admin UIs (see [web #82](https://github.com/ag-tech-group/hera-streamer-invitational-2026-web/issues/82)).

- `POST /auth/accept-tos` doubles as the email-collection gate. When the caller still carries the synthetic placeholder, `email` is **required** in the body; supplying another synthetic value is rejected (no satisfying the gate by re-submitting the placeholder).
- Collisions return `422 {detail: {code: "email_already_registered", …}}` so the frontend can suggest "sign in to that account and link Steam" instead of auto-merging accounts.
- On success the synthetic email is overwritten, `is_verified` is reset to `false`, and a verification email is dispatched via the existing Resend pipeline. Verification is **non-blocking** — dispatch failures are logged but don't fail the request.
- Wires FastAPI-Users' verify router (`/auth/verify`, `/auth/request-verify-token`) so the link in the email has a backend to hit.
- Centralizes synthetic-email construction + detection in `app/auth/steam_email.py`, replacing the inline string in the Steam OAuth handler.

Note on naming: issue #31 references `/accept-terms` and `@steam.criticalbit`; the actual endpoint is `/auth/accept-tos` and the actual placeholder suffix is `@users.criticalbit.gg`. The issue body explicitly said "or whatever the current endpoint is."

Closes #31.

## Backfill

No migration needed. Existing Steam users naturally hit the gate on their next login because the frontend (companion PR in [criticalbit-auth-web #36](https://github.com/ag-tech-group/criticalbit-auth-web/issues/36)) decides based on the email shape, and the backend will only accept their next accept-tos call if it includes a real address.

## Test plan

- [x] `uv run pytest tests/test_accept_tos_email_gate.py` — 17 tests cover synthetic detection (7 cases), non-synthetic users still passing without an email, all 422 paths (email_required, email_invalid, email_already_registered including case-insensitive collisions), happy path (email replaced + is_verified reset + verification dispatched), email normalization (trim + lowercase), and non-blocking behavior when the dispatch raises.
- [x] Full suite: `uv run pytest` — 79 passed, 1 skipped.
- [x] `uv run ruff check` + `uv run ruff format --check` — clean.
- [ ] Manual smoke: log in as a Steam user, POST `/auth/accept-tos` without body → 422; POST with synthetic email → 422; POST with collision → 422; POST with real email → 200, check inbox.