### PR TITLE
feat(users): add GET /users/lookup bulk by-id resolver

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -306,6 +306,8 @@ _AUTH_RATE_LIMITS: dict[str, RateLimitItem] = {
     "POST /auth/refresh": parse("30/minute"),
     # /users/search is auth-bearing but enumeration-adjacent, so cap it.
     "GET /users/search": parse("60/minute"),
+    # /users/lookup is bulk-by-id; low expected volume but still cap.
+    "GET /users/lookup": parse("60/minute"),
 }
 
 

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -1,10 +1,12 @@
 """User lookup endpoints.
 
-Currently exposes a single type-ahead search used by consumer apps that need
-a user picker (e.g. the standings admin tab choosing who to grant ownership
-to). Match keys include email for admin convenience, but email is never in
-the response payload — see :class:`UserSearchResult`.
+Two surfaces with intentionally different shapes:
+- ``/users/search`` — substring picker for type-ahead UI; omits email.
+- ``/users/lookup`` — bulk by-id resolver for privileged consumers; includes
+  email. Trusts the caller to enforce authority over the looked-up users.
 """
+
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy import case, or_, select
@@ -13,17 +15,47 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth import current_active_user
 from app.database import get_async_session
 from app.models.user import User
-from app.schemas.user import UserSearchResult
+from app.schemas.user import UserLookupResult, UserSearchResult
 
 router = APIRouter(prefix="/users", tags=["users"])
 
 MAX_SEARCH_LIMIT = 50
 DEFAULT_SEARCH_LIMIT = 10
 
+MAX_LOOKUP_IDS = 50
+
 
 def _escape_like(value: str) -> str:
     """Escape LIKE wildcards so user input matches literally."""
     return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def _parse_lookup_ids(raw: list[str]) -> list[UUID]:
+    """Flatten + parse the ``ids`` query into a deduped, capped UUID list.
+
+    Accepts both repeated (?ids=a&ids=b) and comma-separated (?ids=a,b)
+    inputs in the same call. Malformed UUIDs and blanks are silently
+    dropped — the contract is "unknown IDs return nothing" and malformed
+    is just a degenerate flavor of unknown.
+    """
+    seen: set[UUID] = set()
+    parsed: list[UUID] = []
+    for entry in raw:
+        for piece in entry.split(","):
+            piece = piece.strip()
+            if not piece:
+                continue
+            try:
+                uid = UUID(piece)
+            except ValueError:
+                continue
+            if uid in seen:
+                continue
+            seen.add(uid)
+            parsed.append(uid)
+            if len(parsed) >= MAX_LOOKUP_IDS:
+                return parsed
+    return parsed
 
 
 @router.get("/search", response_model=list[UserSearchResult])
@@ -73,6 +105,42 @@ async def search_users(
     return [
         UserSearchResult(
             id=user.id,
+            display_name=user.display_name,
+            avatar_url=user.avatar_url,
+        )
+        for user in users
+    ]
+
+
+@router.get("/lookup", response_model=list[UserLookupResult])
+async def lookup_users(
+    ids: list[str] = Query(
+        default_factory=list,
+        description="UUIDs to resolve. Repeat (?ids=a&ids=b) or comma-separate (?ids=a,b).",
+    ),
+    _user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_async_session),
+) -> list[UserLookupResult]:
+    """Bulk by-id user resolver for privileged consumers.
+
+    Unknown IDs are silently omitted — callers detect gaps by diffing input
+    vs output. Malformed UUIDs are treated as unknown rather than 422'd so a
+    single bad entry doesn't kill the whole batch.
+
+    Authority over the looked-up users is the caller's responsibility; this
+    endpoint trusts that boundary and does not try to enforce it.
+    """
+    parsed = _parse_lookup_ids(ids)
+    if not parsed:
+        return []
+
+    stmt = select(User).where(User.id.in_(parsed))
+    result = await session.execute(stmt)
+    users = result.unique().scalars().all()
+    return [
+        UserLookupResult(
+            id=user.id,
+            email=user.email,
             display_name=user.display_name,
             avatar_url=user.avatar_url,
         )

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -37,3 +37,18 @@ class UserSearchResult(BaseModel):
     id: UUID
     display_name: str | None = None
     avatar_url: str | None = None
+
+
+class UserLookupResult(BaseModel):
+    """Projection returned by /users/lookup.
+
+    Includes email — the endpoint is a privileged-context bulk resolver for
+    consumers that already know the user IDs (and so already have authority
+    over the records). Kept separate from UserRead so admin-only fields
+    (role, is_superuser, tos_*) don't leak.
+    """
+
+    id: UUID
+    email: str
+    display_name: str | None = None
+    avatar_url: str | None = None

--- a/tests/test_users_lookup.py
+++ b/tests/test_users_lookup.py
@@ -1,0 +1,255 @@
+"""Tests for GET /users/lookup.
+
+Covers the public contract from issue #34:
+- Auth required (401 anonymous).
+- Empty / missing / all-malformed `ids` returns [] (not 422).
+- Malformed UUID entries are silently dropped alongside valid ones.
+- Unknown IDs are silently omitted from the response.
+- Email IS in the response (unlike /users/search).
+- Accepts both repeated query params and comma-separated values.
+- Capped at MAX_LOOKUP_IDS server-side.
+- Dedup: requesting the same id twice returns it once.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user import User
+from app.routers.users import MAX_LOOKUP_IDS
+
+
+@pytest.fixture
+async def seeded(session: AsyncSession) -> list[User]:
+    """A handful of users with distinct shapes."""
+    users = [
+        User(
+            id=uuid4(),
+            email="alice@example.com",
+            hashed_password="x",
+            display_name="Alice",
+            avatar_url="https://example.com/alice.png",
+        ),
+        User(
+            id=uuid4(),
+            email="bob@example.com",
+            hashed_password="x",
+            display_name="Bob",
+            avatar_url=None,
+        ),
+        User(
+            # No display_name — admin UIs fall back to email.
+            id=uuid4(),
+            email="carol@example.com",
+            hashed_password="x",
+            display_name=None,
+            avatar_url=None,
+        ),
+        User(
+            # Synthetic Steam placeholder — must be returned as-is.
+            id=uuid4(),
+            email="steam_76561198000000077@users.criticalbit.gg",
+            hashed_password="!steam-oauth-no-password",
+            display_name=None,
+            avatar_url=None,
+        ),
+    ]
+    for u in users:
+        session.add(u)
+    await session.commit()
+    return users
+
+
+# --- 401 anonymous ----------------------------------------------------------
+
+
+async def test_anonymous_returns_401(client: AsyncClient) -> None:
+    resp = await client.get(f"/users/lookup?ids={uuid4()}")
+    assert resp.status_code == 401, resp.text
+
+
+# --- empty / missing / malformed → [] (not 422) ----------------------------
+
+
+async def test_missing_ids_returns_empty_array(auth_client: AsyncClient) -> None:
+    resp = await auth_client.get("/users/lookup")
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == []
+
+
+async def test_empty_ids_returns_empty_array(auth_client: AsyncClient) -> None:
+    resp = await auth_client.get("/users/lookup?ids=")
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == []
+
+
+async def test_all_malformed_ids_returns_empty_array(auth_client: AsyncClient) -> None:
+    resp = await auth_client.get("/users/lookup?ids=not-a-uuid&ids=also-bad")
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == []
+
+
+async def test_malformed_mixed_with_valid_silently_drops_bad(
+    auth_client: AsyncClient, seeded: list[User]
+) -> None:
+    alice = seeded[0]
+    resp = await auth_client.get(f"/users/lookup?ids=not-a-uuid&ids={alice.id}")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["id"] == str(alice.id)
+
+
+# --- happy path: known IDs --------------------------------------------------
+
+
+async def test_returns_records_for_known_ids(auth_client: AsyncClient, seeded: list[User]) -> None:
+    alice, bob, *_ = seeded
+    resp = await auth_client.get(f"/users/lookup?ids={alice.id}&ids={bob.id}")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    returned_ids = {row["id"] for row in body}
+    assert returned_ids == {str(alice.id), str(bob.id)}
+
+
+async def test_unknown_ids_silently_omitted(auth_client: AsyncClient, seeded: list[User]) -> None:
+    alice = seeded[0]
+    ghost = uuid4()
+    resp = await auth_client.get(f"/users/lookup?ids={alice.id}&ids={ghost}")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["id"] == str(alice.id)
+
+
+# --- response shape ---------------------------------------------------------
+
+
+async def test_response_includes_email(auth_client: AsyncClient, seeded: list[User]) -> None:
+    # Unlike /users/search, lookup MUST include email — that's the whole
+    # point of the privileged surface.
+    alice = seeded[0]
+    resp = await auth_client.get(f"/users/lookup?ids={alice.id}")
+    body = resp.json()
+    assert resp.status_code == 200
+    assert body[0]["email"] == "alice@example.com"
+    assert set(body[0].keys()) == {"id", "email", "display_name", "avatar_url"}
+
+
+async def test_null_display_and_avatar_are_returned_as_null(
+    auth_client: AsyncClient, seeded: list[User]
+) -> None:
+    carol = seeded[2]
+    resp = await auth_client.get(f"/users/lookup?ids={carol.id}")
+    body = resp.json()
+    assert resp.status_code == 200
+    assert body[0]["display_name"] is None
+    assert body[0]["avatar_url"] is None
+
+
+async def test_synthetic_steam_email_is_returned_as_is(
+    auth_client: AsyncClient, seeded: list[User]
+) -> None:
+    # The lookup endpoint reflects whatever's persisted — Steam users who
+    # haven't hit the accept-tos gate still appear with their synthetic
+    # placeholder, and that's what we return (caller's responsibility to
+    # decide what to render).
+    steam_user = seeded[3]
+    resp = await auth_client.get(f"/users/lookup?ids={steam_user.id}")
+    body = resp.json()
+    assert resp.status_code == 200
+    assert body[0]["email"].endswith("@users.criticalbit.gg")
+
+
+# --- input formats ----------------------------------------------------------
+
+
+async def test_comma_separated_ids_are_supported(
+    auth_client: AsyncClient, seeded: list[User]
+) -> None:
+    alice, bob, *_ = seeded
+    resp = await auth_client.get(f"/users/lookup?ids={alice.id},{bob.id}")
+    assert resp.status_code == 200, resp.text
+    returned = {row["id"] for row in resp.json()}
+    assert returned == {str(alice.id), str(bob.id)}
+
+
+async def test_mixed_repeated_and_comma_formats(
+    auth_client: AsyncClient, seeded: list[User]
+) -> None:
+    alice, bob, carol, *_ = seeded
+    resp = await auth_client.get(f"/users/lookup?ids={alice.id},{bob.id}&ids={carol.id}")
+    assert resp.status_code == 200, resp.text
+    returned = {row["id"] for row in resp.json()}
+    assert returned == {str(alice.id), str(bob.id), str(carol.id)}
+
+
+# --- dedup + cap ------------------------------------------------------------
+
+
+async def test_duplicate_ids_return_single_record(
+    auth_client: AsyncClient, seeded: list[User]
+) -> None:
+    alice = seeded[0]
+    resp = await auth_client.get(f"/users/lookup?ids={alice.id}&ids={alice.id}")
+    body = resp.json()
+    assert resp.status_code == 200
+    assert len(body) == 1
+
+
+async def test_cap_at_max_lookup_ids(auth_client: AsyncClient, session: AsyncSession) -> None:
+    # Seed MAX_LOOKUP_IDS + 5 users, request all of them. Only the first
+    # MAX_LOOKUP_IDS UUIDs should be honored — the extras get dropped at
+    # the parse step, so at most MAX_LOOKUP_IDS records come back.
+    users = [
+        User(
+            id=uuid4(),
+            email=f"u{i}@example.com",
+            hashed_password="x",
+        )
+        for i in range(MAX_LOOKUP_IDS + 5)
+    ]
+    for u in users:
+        session.add(u)
+    await session.commit()
+
+    ids_param = "&".join(f"ids={u.id}" for u in users)
+    resp = await auth_client.get(f"/users/lookup?{ids_param}")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert len(body) == MAX_LOOKUP_IDS
+    # And the kept ones must be a prefix of the input order.
+    expected_kept = {str(u.id) for u in users[:MAX_LOOKUP_IDS]}
+    assert {row["id"] for row in body} == expected_kept
+
+
+# --- UUID with whitespace / blanks -----------------------------------------
+
+
+async def test_blank_entries_in_comma_list_are_dropped(
+    auth_client: AsyncClient, seeded: list[User]
+) -> None:
+    alice = seeded[0]
+    # ", ,a, " — should treat as just "a"
+    resp = await auth_client.get(f"/users/lookup?ids=,,{alice.id},")
+    body = resp.json()
+    assert resp.status_code == 200
+    assert len(body) == 1
+    assert body[0]["id"] == str(alice.id)
+
+
+async def test_uuid_is_canonical_lowercase_in_response(
+    auth_client: AsyncClient, seeded: list[User]
+) -> None:
+    # Request with uppercase, response should still be canonical.
+    alice = seeded[0]
+    resp = await auth_client.get(f"/users/lookup?ids={str(alice.id).upper()}")
+    body = resp.json()
+    assert resp.status_code == 200
+    assert len(body) == 1
+    # uuid round-trips identically regardless of input case.
+    assert UUID(body[0]["id"]) == alice.id


### PR DESCRIPTION
## Summary

Sibling to \`GET /users/search\` (PR #32) but for known IDs. Intended for consumer services that store opaque \`user_id\` columns and need to render the humans behind them (e.g. standings-api owner UIs).

- \`GET /users/lookup?ids=<uuid>&ids=<uuid>\` — also accepts comma-separated (\`?ids=a,b\`); the two formats mix freely in the same call.
- Returns \`[{ id, email, display_name, avatar_url }]\` for each known ID. **Email IS included** (unlike search) — this is the privileged surface for consumers that already have authority over the records.
- Unknown IDs are silently omitted; callers detect gaps by diffing input vs output.
- Malformed UUIDs are treated as unknown (silently dropped) rather than 422, so one bad entry can't kill a batch of 49 good ones.
- Capped at \`MAX_LOOKUP_IDS = 50\`; extras are dropped at parse.
- Empty / missing / all-malformed \`ids\` returns \`[]\` (not 422).
- Rate-limited to 60/min/IP, same shape as \`/users/search\`.

Response schema (\`UserLookupResult\`) is purpose-built rather than reusing \`UserRead\` so admin-only fields (\`role\`, \`is_superuser\`, \`tos_*\`) don't accidentally leak.

Closes #34.

## Design notes

- **GET, not POST.** It's a pure read; URL length at the 50-ID cap is ~2.3KB, far below proxy limits. Issue explicitly calls out POST as a future-only addition if batches grow.
- **Why a separate endpoint vs extending \`/users/search\`?** Different inputs (IDs vs substring), different response shape (with email vs without), different abuse profiles. Keeping them separate from day one prevents accidental PII regressions in search.

## Test plan

- [x] \`uv run pytest tests/test_users_lookup.py\` — 16 tests cover 401, empty/missing/malformed → [], unknown silently omitted, email included, null fields, synthetic Steam email passthrough, both input formats, mixed formats, dedup, server-side cap, blank-entry handling, case-insensitive UUID parsing.
- [x] Full suite: \`uv run pytest\` — 111 passed, 1 skipped.
- [x] \`uv run ruff check\` + \`uv run ruff format --check\` — clean.
- [ ] Manual smoke: \`curl -b cookies.txt 'http://localhost:8001/users/lookup?ids=<known>&ids=<unknown>&ids=garbage'\` — expect one record back for the known ID.