### PR TITLE
fix(migration): correct SQL string for synthetic-email NULLing

### DIFF
--- a/alembic/versions/3748e767182a_make_user_email_nullable.py
+++ b/alembic/versions/3748e767182a_make_user_email_nullable.py
@@ -39,7 +39,7 @@ def upgrade() -> None:
     # for SQL — not a raw string (which would keep the `\"user\"`
     # backslashes literal and break the statement).
     op.execute(
-        "UPDATE \"user\" SET email = NULL "
+        'UPDATE "user" SET email = NULL '
         "WHERE email LIKE 'steam\\_%@users.criticalbit.gg' ESCAPE '\\'"
     )
 

--- a/alembic/versions/3748e767182a_make_user_email_nullable.py
+++ b/alembic/versions/3748e767182a_make_user_email_nullable.py
@@ -33,11 +33,14 @@ def upgrade() -> None:
         existing_type=sa.String(length=320),
         nullable=True,
     )
-    # Postgres treats `\` as the default LIKE escape character, so `\_`
-    # matches a literal underscore (rather than the wildcard meaning).
+    # Postgres's LIKE escape character is set explicitly to `\` so `\_`
+    # matches a literal underscore (rather than the single-char wildcard).
+    # Note the Python string: `\\_` produces the literal `\_` characters
+    # for SQL — not a raw string (which would keep the `\"user\"`
+    # backslashes literal and break the statement).
     op.execute(
-        r"UPDATE \"user\" SET email = NULL "
-        r"WHERE email LIKE 'steam\_%@users.criticalbit.gg'"
+        "UPDATE \"user\" SET email = NULL "
+        "WHERE email LIKE 'steam\\_%@users.criticalbit.gg' ESCAPE '\\'"
     )
 
 


### PR DESCRIPTION
## Summary

Hotfix for the deploy that failed on PR #37's merge. The migration's UPDATE statement used a raw Python string, which kept the \`\\\"user\\\"\` backslashes literal — Postgres received \`\\\"user\\\"\` and failed with \`syntax error at or near \"\\\"\`. The deploy correctly held back the service swap (migrate gates the swap), so prod stayed on the previous image and the schema is unchanged (Alembic wraps PG migrations in a transaction, so the ALTER rolled back with the failed UPDATE).

Fixed by switching to a non-raw string with \`\\\\\"\` for the table-name quotes and \`\\\\_\` for the literal underscore in the LIKE pattern. Made the LIKE escape character explicit with \`ESCAPE '\\\\'\` so the dependency on Postgres's default escape char is documented rather than implicit.

## Test plan

- [x] Python-level sanity check that the produced SQL string is \`UPDATE \"user\" SET email = NULL WHERE email LIKE 'steam\\_%@users.criticalbit.gg' ESCAPE '\\'\` (exact bytes Postgres needs).
- [x] Full suite + lint pass.
- [ ] Re-deploy runs the migrate job successfully; service swap proceeds; \`GET /auth/me\` for a Steam user returns \`email: null\`.