### PR TITLE
feat(auth): email verification + close OAuth merge-by-email takeover vector

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Shared authentication service for [criticalbit.gg](https://criticalbit.gg). Prov
 - Email/password registration and login
 - Google OAuth and Steam OpenID sign-in; link either provider to an existing account
 - Password reset via email (Resend)
+- Email verification (auto-sent on registration); OAuth merge-by-email is refused for unverified accounts to prevent pre-registration takeover
 - RS256-signed JWT access tokens (15 min) in httpOnly cookies scoped to `.criticalbit.gg`, with a public JWKS endpoint so other services can verify them
 - Refresh token rotation with family-based theft detection
 - Role-based authorization (user, admin)
@@ -36,6 +37,8 @@ Shared authentication service for [criticalbit.gg](https://criticalbit.gg). Prov
 | POST | `/auth/refresh` | Rotate the refresh token, mint a new access token |
 | POST | `/auth/forgot-password` | Send a password-reset email |
 | POST | `/auth/reset-password` | Set a new password using the emailed token |
+| POST | `/auth/request-verify-token` | Send a verification email to the given address |
+| POST | `/auth/verify` | Mark the user verified using the emailed token |
 | GET | `/auth/google/authorize` | Begin Google OAuth login (redirects to Google) |
 | GET | `/auth/google/callback` | Google OAuth callback |
 | GET | `/auth/google/associate/authorize` | Link a Google account to the signed-in user |

--- a/alembic/versions/ba7bf686f359_grandfather_existing_users_as_is_.py
+++ b/alembic/versions/ba7bf686f359_grandfather_existing_users_as_is_.py
@@ -1,0 +1,52 @@
+"""grandfather existing users as is_verified
+
+Up to this revision, `is_verified` was wired in the model but never actually
+set to True by any code path — fastapi-users defaults it to False, and
+registration never triggered a verification email. As a result every row in
+the database has is_verified=False.
+
+We're about to start enforcing verification semantics in two places:
+  1. New password registrations now trigger a verification email and stay
+     unverified until the user clicks it.
+  2. OAuth merge-by-email (associate_by_email=True) refuses to link a new
+     Google/etc. login into an existing unverified user — closing a takeover
+     vector where an attacker pre-registers a victim's email.
+
+If we shipped (2) without backfilling, every existing user would suddenly
+fail Google sign-in the next time they used it. Grandfathering the current
+population is safe: the takeover vector is forward-looking (it bites *new*
+unverified rows that haven't been merged yet); rows already in production
+have either already been merged or never will be. Marking them verified
+preserves their working OAuth experience.
+
+Revision ID: ba7bf686f359
+Revises: 3748e767182a
+Create Date: 2026-05-26 15:03:29.185533
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "ba7bf686f359"
+down_revision: str | Sequence[str] | None = "3748e767182a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.execute('UPDATE "user" SET is_verified = TRUE WHERE is_verified = FALSE')
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Not reversible in a meaningful way — we can't tell which rows we
+    flipped from the original state. Leave them verified on downgrade
+    rather than blanket-resetting (which would clobber users who have
+    legitimately verified after this migration ran).
+    """
+    pass

--- a/app/auth/security_logging.py
+++ b/app/auth/security_logging.py
@@ -14,6 +14,7 @@ class SecurityEvent(StrEnum):
     TOKEN_REFRESH = "TOKEN_REFRESH"
     RATE_LIMIT_HIT = "RATE_LIMIT_HIT"
     ACCOUNT_DELETED = "ACCOUNT_DELETED"
+    OAUTH_MERGE_REFUSED = "OAUTH_MERGE_REFUSED"
 
 
 def log_security_event(

--- a/app/auth/users.py
+++ b/app/auth/users.py
@@ -6,7 +6,7 @@ import sqlalchemy as sa
 import structlog
 from fastapi import Depends, Request, Response
 from fastapi.security import OAuth2PasswordRequestForm
-from fastapi_users import BaseUserManager, FastAPIUsers, UUIDIDMixin, models
+from fastapi_users import BaseUserManager, FastAPIUsers, UUIDIDMixin, exceptions, models
 from fastapi_users.db import SQLAlchemyUserDatabase
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -38,6 +38,71 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, UUID]):
             request=request,
             user_id=str(user.id),
             email=user.email,
+        )
+        # Dispatch the verification email. Non-blocking: a Resend outage must
+        # not turn registration into a 500. The user can re-request via
+        # POST /auth/request-verify-token.
+        if user.email and not user.is_verified:
+            try:
+                await self.request_verify(user, request)
+            except Exception:
+                logger.exception("verification.dispatch_failed", user_id=str(user.id))
+
+    async def oauth_callback(
+        self,
+        oauth_name: str,
+        access_token: str,
+        account_id: str,
+        account_email: str,
+        expires_at: int | None = None,
+        refresh_token: str | None = None,
+        request: Request | None = None,
+        *,
+        associate_by_email: bool = False,
+        is_verified_by_default: bool = False,
+    ) -> User:
+        """Hardened OAuth callback that refuses to merge by email into an
+        unverified existing account.
+
+        Without this guard, anyone can pre-register an unverified row with a
+        victim's email; the next time the real victim signs in via this
+        provider, fastapi-users would silently link the attacker's row to the
+        victim's OAuth identity, handing the attacker control of both. The
+        merge is safe only when the existing user has previously proven
+        ownership of the email (is_verified=True).
+        """
+        if associate_by_email:
+            try:
+                await self.get_by_oauth_account(oauth_name, account_id)
+            except exceptions.UserNotExists:
+                try:
+                    existing = await self.get_by_email(account_email)
+                except exceptions.UserNotExists:
+                    pass  # No collision — base will create a fresh user.
+                else:
+                    if not existing.is_verified:
+                        log_security_event(
+                            SecurityEvent.OAUTH_MERGE_REFUSED,
+                            request=request,
+                            user_id=str(existing.id),
+                            email=account_email,
+                            detail=f"oauth_name={oauth_name} reason=existing_unverified",
+                        )
+                        # Raising UserAlreadyExists mirrors the base behavior
+                        # for associate_by_email=False — the OAuth router maps
+                        # it to a 400 with code OAUTH_USER_ALREADY_EXISTS.
+                        raise exceptions.UserAlreadyExists()
+
+        return await super().oauth_callback(
+            oauth_name=oauth_name,
+            access_token=access_token,
+            account_id=account_id,
+            account_email=account_email,
+            expires_at=expires_at,
+            refresh_token=refresh_token,
+            request=request,
+            associate_by_email=associate_by_email,
+            is_verified_by_default=is_verified_by_default,
         )
 
     async def on_after_login(

--- a/tests/test_email_verification.py
+++ b/tests/test_email_verification.py
@@ -1,0 +1,180 @@
+"""Tests for email verification + OAuth merge-by-email takeover guard.
+
+Two concerns:
+
+1. ``POST /auth/register`` must trigger a verification email so the
+   account stays in an "unverified until clicked" state by default.
+   Without this, the ``is_verified`` flag is never set and the
+   ``associate_by_email`` merge guard below has nothing to guard
+   against.
+
+2. ``UserManager.oauth_callback`` must refuse to merge a fresh OAuth
+   identity into an existing user whose email is not verified. This
+   closes the pre-registration takeover vector: an attacker registers
+   ``victim@gmail.com`` with a password they control; later, when the
+   real victim signs in with Google, fastapi-users would otherwise
+   silently link the Google identity to the attacker's row.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi_users import exceptions
+from fastapi_users.db import SQLAlchemyUserDatabase
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import users as users_module
+from app.auth.users import UserManager
+from app.models.oauth_account import OAuthAccount
+from app.models.user import User
+
+# --- helpers ---------------------------------------------------------------
+
+
+@pytest.fixture
+def captured_verification_emails(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+    """Capture verification emails without hitting Resend."""
+    captured: list[dict] = []
+
+    def _capture(email: str, token: str) -> None:
+        captured.append({"email": email, "token": token})
+
+    monkeypatch.setattr(users_module, "send_verification_email", _capture)
+    return captured
+
+
+async def _manager_for(session: AsyncSession) -> UserManager:
+    """Build a UserManager bound to the given test session."""
+    user_db = SQLAlchemyUserDatabase(session, User, OAuthAccount)
+    return UserManager(user_db)
+
+
+# --- (1) register triggers verification email ------------------------------
+
+
+async def test_register_triggers_verification_email(
+    client: AsyncClient,
+    captured_verification_emails: list[dict],
+) -> None:
+    resp = await client.post(
+        "/auth/register",
+        json={"email": "new-user@example.com", "password": "correct horse battery"},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["email"] == "new-user@example.com"
+    assert body["is_verified"] is False
+
+    assert len(captured_verification_emails) == 1, captured_verification_emails
+    sent = captured_verification_emails[0]
+    assert sent["email"] == "new-user@example.com"
+    assert sent["token"]  # JWT-shaped; just confirm we got one
+
+
+# --- (2) oauth_callback refuses merge into unverified existing user --------
+
+
+async def test_oauth_merge_refused_for_unverified_existing_user(
+    session: AsyncSession,
+    captured_verification_emails: list[dict],
+) -> None:
+    """The pre-registration takeover vector. An attacker has created an
+    unverified row with the victim's email; a Google sign-in for that email
+    must NOT silently link to that row."""
+    victim_email = "victim@example.com"
+    attacker_row = User(
+        id=uuid4(),
+        email=victim_email,
+        hashed_password="attacker-controlled",
+        is_active=True,
+        is_verified=False,
+    )
+    session.add(attacker_row)
+    await session.commit()
+
+    manager = await _manager_for(session)
+    with pytest.raises(exceptions.UserAlreadyExists):
+        await manager.oauth_callback(
+            oauth_name="google",
+            access_token="fake-google-token",
+            account_id="google-account-id-12345",
+            account_email=victim_email,
+            associate_by_email=True,
+        )
+
+    # And confirm no link was written.
+    from sqlalchemy import select
+
+    rows = (
+        (await session.execute(select(OAuthAccount).where(OAuthAccount.oauth_name == "google")))
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+
+async def test_oauth_merge_allowed_for_verified_existing_user(
+    session: AsyncSession,
+) -> None:
+    """Once the existing user is verified, the merge proceeds as before."""
+    legit_email = "real-user@example.com"
+    legit_row = User(
+        id=uuid4(),
+        email=legit_email,
+        hashed_password="legit-password",
+        is_active=True,
+        is_verified=True,  # the only thing that differs from the test above
+    )
+    session.add(legit_row)
+    await session.commit()
+    legit_id: UUID = legit_row.id
+
+    manager = await _manager_for(session)
+    user = await manager.oauth_callback(
+        oauth_name="google",
+        access_token="fake-google-token",
+        account_id="google-account-id-67890",
+        account_email=legit_email,
+        associate_by_email=True,
+    )
+
+    assert user.id == legit_id, "merge should have returned the existing user"
+
+    from sqlalchemy import select
+
+    rows = (
+        (
+            await session.execute(
+                select(OAuthAccount).where(
+                    OAuthAccount.oauth_name == "google",
+                    OAuthAccount.account_id == "google-account-id-67890",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1, "exactly one Google link should now exist"
+    assert rows[0].user_id == legit_id
+
+
+async def test_oauth_create_fresh_user_when_no_email_collision(
+    session: AsyncSession,
+) -> None:
+    """No existing email match → base behavior creates a new user. The guard
+    must not interfere with this happy path."""
+    manager = await _manager_for(session)
+    user = await manager.oauth_callback(
+        oauth_name="google",
+        access_token="fake-google-token",
+        account_id="google-account-id-fresh",
+        account_email="brand-new@example.com",
+        associate_by_email=True,
+    )
+
+    assert user.email == "brand-new@example.com"
+    # fastapi-users sets is_verified from is_verified_by_default=False here.
+    assert user.is_verified is False


### PR DESCRIPTION
## Summary

- Wire up email verification on registration. `on_after_register` now dispatches via `request_verify` so password registrants automatically receive a verification email (Resend → frontend `/verify-email?token=…` link). All the plumbing already existed (`get_verify_router`, `on_after_request_verify`, `send_verification_email`); we were just never calling `request_verify`.
- Close a pre-registration takeover vector. `UserManager.oauth_callback` is overridden to refuse the `associate_by_email=True` merge when the existing user has `is_verified=False`. Without this guard, an attacker who registers `victim@gmail.com` with a password they control would receive a silent OAuth link the next time the real victim signed in with Google.
- One-time alembic backfill marks the current user population `is_verified=true`. The takeover vector is forward-looking — rows already in production have either been merged or never will be — so grandfathering is safe and preserves existing users' working Google sign-in.
- New `SecurityEvent.OAUTH_MERGE_REFUSED` for observability on refused merges.

## Why this matters

`associate_by_email=True` is set on the Google OAuth router in `app/main.py`. fastapi-users implements that as: when a Google identity arrives, look up an existing user by email; if found, silently link. That pattern is only safe when the existing user has proven ownership of the email — i.e., verified it. Today no user has, because verification was never wired into the registration flow.

The fix is two-sided: (1) start verifying email ownership on registration so future accounts have a meaningful `is_verified` flag, and (2) require that flag to be true before allowing an OAuth merge to land on an existing account. The migration grandfathers existing users so the new guard doesn't break their next Google sign-in.

## Test plan

- [x] `uv run pytest` — 106 passed (1 pre-existing skip). New `tests/test_email_verification.py` covers registration triggering the email, merge refusal for unverified existing user, merge allowed for verified existing user, fresh-create unaffected.
- [x] `uv run ruff check . && uv run ruff format --check .` — clean.
- [x] Migration applied against a clean Postgres: all 8 migrations including the new `ba7bf686f359` ran. Downgrading one step, inserting an unverified user, then re-upgrading correctly flipped `is_verified` from `f` to `t`.
- [x] `POST /auth/register` against the local API logged the `email.skipped` event with the verify URL containing a well-formed JWT (RESEND_API_KEY unset locally).
- [x] `POST /auth/verify` with that token returned `is_verified: true` and the DB row reflects it.
- [ ] Frontend follow-up tracked in `ag-tech-group/criticalbit-auth-web#11` — the `/verify-email` page needs to exist for end users to actually click through, and the OAuth callback page should surface a clearer error when the new `OAUTH_USER_ALREADY_EXISTS` refusal fires.

## Migration safety

`UPDATE "user" SET is_verified = TRUE WHERE is_verified = FALSE` — idempotent, single-statement, no schema change. Runs once at deploy time. Downgrade is a no-op (we can't tell which rows we flipped from the original state once new verifications start landing, so a blanket reset would clobber legitimately-verified users).