### PR TITLE
feat(auth): unlink connections + has_usable_password tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Shared authentication service for [criticalbit.gg](https://criticalbit.gg). Prov
 - Email/password registration and login
 - Pluggable identity providers (Google OAuth2, Steam OpenID 2.0) via a registry — adding a new provider (Twitch, Battle.net, YouTube, ...) is a single file in `app/providers/`
 - Bidirectional account linking: any provider can be linked to any account regardless of how the account was originally created
+- Connection management: list and disconnect linked providers, with a safety rule that refuses to leave a user with no usable login method
 - Password reset via email (Resend)
 - Email verification (auto-sent on registration); OAuth merge-by-email is refused for unverified accounts to prevent pre-registration takeover
 - RS256-signed JWT access tokens (15 min) in httpOnly cookies scoped to `.criticalbit.gg`, with a public JWKS endpoint so other services can verify them
@@ -45,7 +46,8 @@ Shared authentication service for [criticalbit.gg](https://criticalbit.gg). Prov
 | GET | `/auth/{provider}/associate/authorize` | Link a provider account to the signed-in user (bidirectional) |
 | GET | `/auth/{provider}/associate/callback` | Provider link callback |
 | GET | `/auth/me/connections` | List the signed-in user's linked providers |
-| GET | `/auth/me` | Get the current user's profile |
+| DELETE | `/auth/me/connections/{provider}` | Unlink a provider (refused if it would leave no login method) |
+| GET | `/auth/me` | Get the current user's profile (includes `has_usable_password`) |
 | PATCH | `/auth/me` | Update the current user's profile |
 | DELETE | `/auth/me` | Delete the current user's account |
 | POST | `/auth/accept-tos` | Accept the current Terms of Service version |

--- a/alembic/versions/f90bb6976e65_add_user_has_usable_password.py
+++ b/alembic/versions/f90bb6976e65_add_user_has_usable_password.py
@@ -1,0 +1,58 @@
+"""add user.has_usable_password
+
+Tracks whether the user can authenticate with a password they actually
+know. ``hashed_password`` alone can't tell us:
+
+  - Email-registered users have a hash of a password they chose.
+  - Google-created users (fastapi-users' OAuth flow) have a hash of a
+    server-generated random password they don't know.
+  - Steam-created users have the ``!steam-oauth-no-password`` sentinel.
+
+The new column is set ``True`` on ``/auth/register`` and on
+``/auth/reset-password``. ``DELETE /auth/me/connections/{provider}``
+uses it to refuse unlinks that would leave a user with no usable login
+method.
+
+Backfill choice: ``DEFAULT FALSE`` for everyone, including existing
+email-registered users. We can't reliably tell from ``hashed_password``
+alone which existing rows correspond to chosen passwords vs.
+OAuth-generated ones. The conservative default prevents accidental
+lockouts (a known-password user is mildly inconvenienced — they go
+through forgot-password to claim the flag — but no one gets stranded
+because the API rubber-stamped them as "has password").
+
+Revision ID: f90bb6976e65
+Revises: 2008c89eede8
+Create Date: 2026-05-26 15:55:36.341844
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f90bb6976e65"
+down_revision: str | Sequence[str] | None = "2008c89eede8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "user",
+        sa.Column(
+            "has_usable_password",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("user", "has_usable_password")

--- a/app/auth/users.py
+++ b/app/auth/users.py
@@ -39,6 +39,11 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, UUID]):
             user_id=str(user.id),
             email=user.email,
         )
+        # Mark the password as usable — the user chose it and presumably
+        # remembers it. Used downstream by the unlink safety rule so we
+        # don't refuse a disconnect for password-registered users.
+        await self.user_db.update(user, {"has_usable_password": True})
+
         # Dispatch the verification email. Non-blocking: a Resend outage must
         # not turn registration into a 500. The user can re-request via
         # POST /auth/request-verify-token.
@@ -47,6 +52,12 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, UUID]):
                 await self.request_verify(user, request)
             except Exception:
                 logger.exception("verification.dispatch_failed", user_id=str(user.id))
+
+    async def on_after_reset_password(self, user: User, request: Request | None = None):
+        """A successful password reset means the user just demonstrated
+        ownership of a password they (now) know. Flip the flag so they can
+        unlink OAuth providers without getting stranded."""
+        await self.user_db.update(user, {"has_usable_password": True})
 
     async def oauth_callback(
         self,

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from fastapi_users.db import SQLAlchemyBaseUserTableUUID
-from sqlalchemy import DateTime, String
+from sqlalchemy import Boolean, DateTime, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
@@ -21,6 +21,15 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
     email until they pass through the accept-tos gate (issue #31). The
     unique index still works on nullable columns — Postgres and SQLite
     both permit multiple NULLs in a UNIQUE index by default.
+
+    `has_usable_password` tracks whether the user can actually log in with
+    a password they know — `hashed_password` alone can't tell us this:
+    fastapi-users' OAuth flow stores a random server-generated hash on
+    Google-created users (PR #40), and Steam-created users carry the
+    `!steam-oauth-no-password` sentinel. We flip this to True on
+    `/auth/register` and on successful `/auth/reset-password`. The
+    `DELETE /auth/me/connections/{provider}` endpoint uses it to refuse
+    unlinks that would leave a user with no usable login method.
     """
 
     email: Mapped[str | None] = mapped_column(
@@ -33,6 +42,9 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
     avatar_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     tos_accepted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     tos_version: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    has_usable_password: Mapped[bool] = mapped_column(
+        Boolean, default=False, server_default="false", nullable=False
+    )
 
     oauth_accounts: Mapped[list["OAuthAccount"]] = relationship(  # noqa: F821
         "OAuthAccount", lazy="joined"

--- a/app/routers/auth_providers.py
+++ b/app/routers/auth_providers.py
@@ -501,6 +501,83 @@ async def list_connections(
     ]
 
 
+@router.delete("/me/connections/{provider_name}", status_code=status.HTTP_204_NO_CONTENT)
+async def unlink_connection(
+    provider_name: str,
+    request: Request,
+    user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_async_session),
+) -> Response:
+    """Unlink ``provider_name`` from the signed-in user.
+
+    Refuses with 409 ``unlink_would_strand_user`` when removing this link
+    would leave the user with no usable login method — i.e., no other
+    OAuth connection AND no usable password (or no email to use it with).
+    The user must either link another provider first or set/reset a
+    password (which flips ``has_usable_password`` to True).
+    """
+    result = await session.execute(
+        select(OAuthAccount).where(
+            OAuthAccount.user_id == user.id,
+            OAuthAccount.oauth_name == provider_name,
+        )
+    )
+    row = result.scalar_one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "code": "connection_not_found",
+                "message": f"You don't have a {provider_name} account linked.",
+                "provider": provider_name,
+            },
+        )
+
+    # Count remaining OAuth connections after this hypothetical unlink.
+    remaining_oauth_result = await session.execute(
+        select(OAuthAccount).where(
+            OAuthAccount.user_id == user.id,
+            OAuthAccount.oauth_name != provider_name,
+        )
+    )
+    remaining_oauth = remaining_oauth_result.scalars().all()
+    has_password_login = bool(user.has_usable_password and user.email)
+
+    if not remaining_oauth and not has_password_login:
+        # Helpful structured response so the frontend can render guidance.
+        suggestions: list[str] = []
+        if not user.email:
+            suggestions.append("link an account that provides an email (e.g. Google) first")
+        elif not user.has_usable_password:
+            suggestions.append("set a password via /auth/forgot-password first")
+        if not remaining_oauth:
+            suggestions.append("link another provider first")
+
+        log_security_event(
+            SecurityEvent.OAUTH_MERGE_REFUSED,
+            request=request,
+            user_id=str(user.id),
+            detail=f"unlink_refused provider={provider_name} reason=would_strand",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "unlink_would_strand_user",
+                "message": (
+                    "Disconnecting this account would leave you with no way to sign "
+                    "in. " + " Or ".join(suggestions) + "."
+                ),
+                "provider": provider_name,
+                "remediation": suggestions,
+            },
+        )
+
+    await session.delete(row)
+    await session.commit()
+    logger.info("oauth.unlinked", provider=provider_name, user_id=str(user.id))
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
 # --- Router factory -------------------------------------------------------
 
 

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -10,6 +10,12 @@ class UserRead(schemas.BaseUser[UUID]):
 
     `email` is `None` for Steam OAuth users who haven't passed through the
     accept-tos email-collection gate (issue #36).
+
+    `has_usable_password` is True iff the user can sign in with email +
+    password (registered via `/auth/register` or completed
+    `/auth/reset-password`). Used by the frontend to decide whether the
+    "Disconnect" button on a linked provider should be enabled — if it's
+    the user's only login method, disconnecting would strand them.
     """
 
     email: EmailStr | None = None  # type: ignore[assignment]
@@ -18,6 +24,7 @@ class UserRead(schemas.BaseUser[UUID]):
     avatar_url: str | None = None
     tos_accepted_at: datetime | None = None
     tos_version: str | None = None
+    has_usable_password: bool = False
 
 
 class UserCreate(schemas.BaseUserCreate):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,28 +52,55 @@ async def session() -> AsyncGenerator[AsyncSession, None]:
         yield session
 
 
+def _user(**overrides) -> User:
+    """Construct a User with explicit defaults for every non-PK column.
+
+    SQLAlchemy's ``default=`` and ``server_default=`` only fire at flush
+    time. Tests that pass the user through ``dependency_overrides`` never
+    hit a flush, so unset columns come back as ``None`` — which Pydantic
+    response validation then rejects (e.g. ``has_usable_password: bool``).
+    Centralizing the defaults here keeps each fixture readable and means
+    adding a new column only requires updating this one helper.
+    """
+    base: dict = {
+        "id": uuid4(),
+        "hashed_password": "fake",
+        "is_active": True,
+        "is_superuser": False,
+        "is_verified": False,
+        "role": "user",
+        "display_name": None,
+        "avatar_url": None,
+        "tos_accepted_at": None,
+        "tos_version": None,
+        "has_usable_password": False,
+    }
+    base.update(overrides)
+    return User(**base)
+
+
 @pytest.fixture
 def test_user() -> User:
     """A test user for authenticated endpoints."""
-    return User(id=uuid4(), email="test@example.com", hashed_password="fake")
+    return _user(email="test@example.com")
 
 
 @pytest.fixture
 def other_user() -> User:
     """A second test user for isolation tests."""
-    return User(id=uuid4(), email="other@example.com", hashed_password="fake")
+    return _user(email="other@example.com")
 
 
 @pytest.fixture
 def admin_user() -> User:
     """A user with the admin role."""
-    return User(id=uuid4(), email="admin@example.com", hashed_password="fake", role="admin")
+    return _user(email="admin@example.com", role="admin")
 
 
 @pytest.fixture
 def superuser() -> User:
     """A superuser (bypasses role checks)."""
-    return User(id=uuid4(), email="super@example.com", hashed_password="fake", is_superuser=True)
+    return _user(email="super@example.com", is_superuser=True)
 
 
 @pytest.fixture

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -107,6 +107,7 @@ class TestAuthMeIncludesRole:
             is_active=True,
             is_superuser=False,
             is_verified=False,
+            has_usable_password=False,
         )
         app.dependency_overrides[current_active_user] = lambda: user
         try:
@@ -126,6 +127,7 @@ class TestAuthMeIncludesRole:
             is_active=True,
             is_superuser=False,
             is_verified=False,
+            has_usable_password=False,
         )
         app.dependency_overrides[current_active_user] = lambda: user
         try:

--- a/tests/test_unlink_connection.py
+++ b/tests/test_unlink_connection.py
@@ -1,0 +1,393 @@
+"""Tests for the connection-unlink endpoint and password-usability tracking.
+
+The unlink endpoint is the matching half of the bidirectional linking
+landed in PR #40. The safety rule is the load-bearing piece: the API
+MUST refuse to disconnect a provider if doing so leaves the user with no
+way back in.
+
+Three sub-stories covered here:
+
+1. ``has_usable_password`` lifecycle. Set on register; set on
+   reset-password; defaulted False for everyone else so we don't lie
+   about user state.
+2. ``DELETE /auth/me/connections/{provider}`` success path — works when
+   the user has either a remaining OAuth link OR a usable password.
+3. The safety rule — refuses (409) when removing the link would strand
+   the user with no usable login method, and the response includes a
+   ``remediation`` array the frontend can render as actionable hints.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import current_active_user
+from app.auth import users as users_module
+from app.main import app
+from app.models.oauth_account import OAuthAccount
+from app.models.user import User
+
+# --- has_usable_password lifecycle ----------------------------------------
+
+
+@pytest.fixture
+def silence_verification_email(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The register tests don't care about the verification email; mute it
+    so we don't get warning logs about a missing RESEND_API_KEY."""
+    monkeypatch.setattr(users_module, "send_verification_email", lambda email, token: None)
+
+
+class TestHasUsablePasswordLifecycle:
+    async def test_register_flips_flag_to_true(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        silence_verification_email: None,
+    ) -> None:
+        resp = await client.post(
+            "/auth/register",
+            json={"email": "password-user@example.com", "password": "tr0mbones-arpeggio"},
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["has_usable_password"] is True
+
+        # And confirm it was persisted.
+        row = (
+            (await session.execute(select(User).where(User.email == "password-user@example.com")))
+            .unique()
+            .scalar_one()
+        )
+        assert row.has_usable_password is True
+
+    async def test_reset_password_flips_flag_to_true(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A user with no usable password (e.g. Steam-created who later
+        provided an email) completes /auth/reset-password and the flag
+        flips. Drives the public endpoints rather than minting the JWT
+        by hand — that way we exercise the full lifecycle hook chain."""
+
+        seed_email = "oauth-user@example.com"
+        seed = User(
+            id=uuid4(),
+            email=seed_email,
+            hashed_password="!steam-oauth-no-password",
+            is_active=True,
+            is_verified=True,
+            has_usable_password=False,
+        )
+        session.add(seed)
+        await session.commit()
+
+        # Capture the reset token via the email-dispatch seam.
+        captured: dict[str, str] = {}
+
+        def _capture(email: str, token: str) -> None:
+            captured["email"] = email
+            captured["token"] = token
+
+        monkeypatch.setattr(users_module, "send_reset_password_email", _capture)
+
+        forgot_resp = await client.post(
+            "/auth/forgot-password", json={"email": seed_email}
+        )
+        assert forgot_resp.status_code == 202, forgot_resp.text
+        assert captured.get("token"), "forgot-password should have dispatched a token"
+
+        reset_resp = await client.post(
+            "/auth/reset-password",
+            json={"token": captured["token"], "password": "newly-set-password-789"},
+        )
+        assert reset_resp.status_code == 200, reset_resp.text
+
+        # Force the test session to re-fetch this row from the DB rather than
+        # serving the cached instance from before the HTTP request modified it.
+        await session.refresh(seed)
+        assert seed.has_usable_password is True
+
+    async def test_unrelated_user_creation_leaves_flag_false(self, session: AsyncSession) -> None:
+        """Sanity: a User created without going through register should
+        default has_usable_password=False (the conservative default)."""
+        user = User(
+            id=uuid4(),
+            email=None,
+            hashed_password="!steam-oauth-no-password",
+            is_active=True,
+            is_verified=False,
+        )
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        assert user.has_usable_password is False
+
+
+# --- DELETE /auth/me/connections/{provider} happy paths -------------------
+
+
+def _override_user(user: User):
+    app.dependency_overrides[current_active_user] = lambda: user
+
+
+def _clear_user_override():
+    app.dependency_overrides.pop(current_active_user, None)
+
+
+@pytest.fixture
+async def user_with_password_and_two_providers(session: AsyncSession) -> User:
+    user = User(
+        id=uuid4(),
+        email="multi-login@example.com",
+        hashed_password="real-hash",
+        is_active=True,
+        is_verified=True,
+        has_usable_password=True,
+    )
+    session.add(user)
+    session.add(
+        OAuthAccount(
+            user_id=user.id,
+            oauth_name="google",
+            access_token="g-token",
+            account_id="google-uid-1",
+            account_email="multi-login@example.com",
+        )
+    )
+    session.add(
+        OAuthAccount(
+            user_id=user.id,
+            oauth_name="steam",
+            access_token="",
+            account_id="76561198000000999",
+            account_email="",
+        )
+    )
+    await session.commit()
+    return user
+
+
+@pytest.fixture
+async def steam_only_user(session: AsyncSession) -> User:
+    user = User(
+        id=uuid4(),
+        email=None,
+        hashed_password="!steam-oauth-no-password",
+        is_active=True,
+        is_verified=False,
+        has_usable_password=False,
+    )
+    session.add(user)
+    session.add(
+        OAuthAccount(
+            user_id=user.id,
+            oauth_name="steam",
+            access_token="",
+            account_id="76561198000000123",
+            account_email="",
+        )
+    )
+    await session.commit()
+    return user
+
+
+@pytest.fixture
+async def password_user_with_one_link(session: AsyncSession) -> User:
+    user = User(
+        id=uuid4(),
+        email="pw-and-google@example.com",
+        hashed_password="real-hash",
+        is_active=True,
+        is_verified=True,
+        has_usable_password=True,
+    )
+    session.add(user)
+    session.add(
+        OAuthAccount(
+            user_id=user.id,
+            oauth_name="google",
+            access_token="g-token",
+            account_id="google-uid-99",
+            account_email="pw-and-google@example.com",
+        )
+    )
+    await session.commit()
+    return user
+
+
+class TestUnlinkSuccess:
+    async def test_unlink_one_of_two_oauth_providers(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        user_with_password_and_two_providers: User,
+    ) -> None:
+        user = user_with_password_and_two_providers
+        _override_user(user)
+        try:
+            resp = await client.delete("/auth/me/connections/google")
+        finally:
+            _clear_user_override()
+        assert resp.status_code == 204, resp.text
+
+        rows = (
+            (await session.execute(select(OAuthAccount).where(OAuthAccount.user_id == user.id)))
+            .scalars()
+            .all()
+        )
+        names = {r.oauth_name for r in rows}
+        assert names == {"steam"}, rows
+
+    async def test_unlink_when_password_login_remains(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        password_user_with_one_link: User,
+    ) -> None:
+        """User has email+password AND one Google link. Unlinking Google is
+        allowed because they still have password login."""
+        user = password_user_with_one_link
+        _override_user(user)
+        try:
+            resp = await client.delete("/auth/me/connections/google")
+        finally:
+            _clear_user_override()
+        assert resp.status_code == 204, resp.text
+
+
+# --- 404 path -------------------------------------------------------------
+
+
+class TestUnlinkNotFound:
+    async def test_returns_404_for_unlinked_provider(
+        self,
+        client: AsyncClient,
+        password_user_with_one_link: User,
+    ) -> None:
+        _override_user(password_user_with_one_link)
+        try:
+            resp = await client.delete("/auth/me/connections/steam")
+        finally:
+            _clear_user_override()
+        assert resp.status_code == 404, resp.text
+        assert resp.json()["detail"]["code"] == "connection_not_found"
+
+
+# --- safety rule ----------------------------------------------------------
+
+
+class TestUnlinkSafetyRule:
+    async def test_steam_only_user_cannot_unlink_steam(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        steam_only_user: User,
+    ) -> None:
+        """The Steam-only user has no email, no password, and only one
+        OAuth connection. Disconnecting Steam would leave them with
+        nothing — refuse."""
+        _override_user(steam_only_user)
+        try:
+            resp = await client.delete("/auth/me/connections/steam")
+        finally:
+            _clear_user_override()
+        assert resp.status_code == 409, resp.text
+        detail = resp.json()["detail"]
+        assert detail["code"] == "unlink_would_strand_user"
+        # The Steam-only user lacks BOTH an email and a password, so the
+        # remediation should mention linking an email-bearing provider.
+        remediation = detail["remediation"]
+        assert any("email" in r for r in remediation), remediation
+
+        # And confirm the row wasn't deleted.
+        rows = (
+            (
+                await session.execute(
+                    select(OAuthAccount).where(OAuthAccount.user_id == steam_only_user.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+
+    async def test_user_with_email_but_no_password_cannot_unlink_only_oauth(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+    ) -> None:
+        """An OAuth user who passed through the email gate but never set a
+        password still can't unlink their only OAuth — the password isn't
+        usable until they go through reset-password."""
+        user = User(
+            id=uuid4(),
+            email="reset-me@example.com",
+            hashed_password="!google-oauth-generated",  # opaque to user
+            is_active=True,
+            is_verified=True,
+            has_usable_password=False,
+        )
+        session.add(user)
+        session.add(
+            OAuthAccount(
+                user_id=user.id,
+                oauth_name="google",
+                access_token="g-token",
+                account_id="google-uid-foo",
+                account_email="reset-me@example.com",
+            )
+        )
+        await session.commit()
+
+        _override_user(user)
+        try:
+            resp = await client.delete("/auth/me/connections/google")
+        finally:
+            _clear_user_override()
+        assert resp.status_code == 409, resp.text
+        detail = resp.json()["detail"]
+        assert detail["code"] == "unlink_would_strand_user"
+        # The user has an email but no usable password — remediation should
+        # mention setting a password.
+        remediation = detail["remediation"]
+        assert any("password" in r for r in remediation), remediation
+
+
+# --- /auth/me exposes has_usable_password --------------------------------
+
+
+class TestUserReadShape:
+    async def test_me_includes_has_usable_password(
+        self,
+        client: AsyncClient,
+        password_user_with_one_link: User,
+    ) -> None:
+        _override_user(password_user_with_one_link)
+        try:
+            resp = await client.get("/auth/me")
+        finally:
+            _clear_user_override()
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["has_usable_password"] is True
+
+    async def test_me_reports_false_for_oauth_only_user(
+        self,
+        client: AsyncClient,
+        steam_only_user: User,
+    ) -> None:
+        _override_user(steam_only_user)
+        try:
+            resp = await client.get("/auth/me")
+        finally:
+            _clear_user_override()
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["has_usable_password"] is False

--- a/tests/test_unlink_connection.py
+++ b/tests/test_unlink_connection.py
@@ -97,9 +97,7 @@ class TestHasUsablePasswordLifecycle:
 
         monkeypatch.setattr(users_module, "send_reset_password_email", _capture)
 
-        forgot_resp = await client.post(
-            "/auth/forgot-password", json={"email": seed_email}
-        )
+        forgot_resp = await client.post("/auth/forgot-password", json={"email": seed_email})
         assert forgot_resp.status_code == 202, forgot_resp.text
         assert captured.get("token"), "forgot-password should have dispatched a token"
 


### PR DESCRIPTION
## Summary

Closes the bidirectional-linking story by adding the unlink half. The load-bearing piece is the safety rule: the API MUST refuse to disconnect a provider if doing so would leave the user with no usable login method.

Three coupled changes:

1. **New `User.has_usable_password` column** (NOT NULL DEFAULT FALSE). We can't tell from `hashed_password` alone which users have a password they actually know — email-registered users do, but Google-created users carry a fastapi-users-generated random hash, and Steam-created users carry the `!steam-oauth-no-password` sentinel. The new flag flips True on `/auth/register` and on successful `/auth/reset-password`.

2. **`DELETE /auth/me/connections/{provider_name}`**. Returns:
   - **204** on success.
   - **404 `connection_not_found`** when the user has no link for that provider.
   - **409 `unlink_would_strand_user`** when removing it would leave the user with no remaining OAuth connection AND no usable password (or no email to use it with). The body includes a `remediation` array the frontend renders as actionable links: "set a password" → `/forgot-password`, "link another provider" → `/settings/connections`, etc.

3. **`has_usable_password` exposed on `UserRead`** so the frontend can pre-compute per-connection unlinkability without an extra round-trip.

## Backfill semantics

The migration sets `has_usable_password = FALSE` for everyone, including existing email-registered users. The alternative — defaulting True — would lie about Google-created users' state and let them lock themselves out by unlinking Google. Conservative False forces known-password users through one extra flow (forgot-password) to claim the flag, but no one gets stranded.

Operationally: the first time someone with an existing password tries to disconnect their only OAuth provider, they'll get the 409 and the remediation hint pointing at `/forgot-password`. One round-trip, password unchanged (they reset to the same value if they want), flag flipped, can now unlink.

## Test plan

- [x] `uv run pytest` — **125 passed**, 1 skipped (same pre-existing skip). New `tests/test_unlink_connection.py` covers:
  - `has_usable_password` flips True on `/auth/register`.
  - `has_usable_password` flips True on full `/auth/forgot-password` → `/auth/reset-password` flow.
  - Unrelated user creation defaults the flag to False.
  - Unlink succeeds when remaining OAuth exists.
  - Unlink succeeds when password login remains.
  - Unlink returns 404 for a provider the user doesn't have linked.
  - Steam-only user can't unlink Steam (would strand; remediation mentions linking an email-providing account).
  - Email-having user with no usable password can't unlink only OAuth (remediation mentions setting a password).
  - `/auth/me` includes `has_usable_password` for both True and False cases.
- [x] `uv run ruff check . && uv run ruff format --check .` — clean.
- [x] Migration applied against a clean Postgres: `\d "user"` shows `has_usable_password | boolean | not null | false`.
- [x] Local end-to-end: register a fresh user → response shows `has_usable_password: true`, persisted in DB. `/auth/me/connections` returns `[]`. `DELETE /auth/me/connections/google` for a user with nothing linked returns the structured 404.

## Test-fixture fix bundled in

Latent: SQLAlchemy's `default=` only fires on flush, not on raw instantiation. The shared `User` test fixtures in `conftest.py` passed through `dependency_overrides` without going to the DB, so `role` had been silently None all along — no test happened to read it via `/auth/me`. Adding `has_usable_password` to `UserRead` surfaced the issue. Fixed by centralizing all column defaults in a `_user(**overrides)` helper.

## Frontend follow-up

Auth-web side needs to:
- Read `has_usable_password` from `/auth/me`.
- Use it + `/auth/me/connections` to decide which Disconnect buttons to enable per provider.
- Handle the 409 response — show the `remediation` items as a list with clickable hints.

I'll file that as a follow-up issue against `ag-tech-group/criticalbit-auth-web` once this merges.

## Migration safety

Single `ADD COLUMN ... NOT NULL DEFAULT FALSE` — atomic, no data backfill required (the server_default does it inline). No downtime concern.