### PR TITLE
fix(rate-limit): key limiter on real client IP behind Cloudflare (#47)

### DIFF
--- a/app/limiting.py
+++ b/app/limiting.py
@@ -1,0 +1,100 @@
+"""Real-client-IP resolution for rate-limit bucketing (issue #47).
+
+The API runs on Cloud Run behind Cloudflare (``auth.criticalbit.gg`` is in
+the CF-proxied ``criticalbit.gg`` zone). ``slowapi``'s stock
+``get_remote_address`` returns ``request.client.host`` — the *peer* that
+opened the TCP connection. Behind Cloudflare that peer is a Cloudflare
+**edge** IP, shared by every client routed through it, so keying the
+limiter on it collapses the whole audience into a handful of edge buckets.
+For the login limiter that means (a) false lockouts for legit users who
+happen to share an edge under load, and (b) no real per-attacker limit —
+the opposite of the brute-force protection it exists to provide.
+
+The fix keys on the real client IP that Cloudflare forwards in
+``CF-Connecting-IP``. But that header is only trustworthy when the request
+actually arrived *through* Cloudflare: the Cloud Run origin's ``*.run.app``
+URL is publicly reachable unless ingress is locked down, so a direct caller
+could otherwise send a fresh ``CF-Connecting-IP`` on every request and sail
+straight past the login limiter — a worse position than the edge-IP bug.
+So we trust the forwarded header **only when the connecting peer is itself
+within Cloudflare's published IP ranges**. For any other peer — a direct
+hit, a spoof attempt, a local test client — we fall back to the peer
+address and the limiter still bites.
+
+Cloudflare's ranges are published at https://www.cloudflare.com/ips/ and
+change rarely. If CF adds a range we don't list, requests via it degrade
+safely to peer-IP bucketing rather than failing open.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+
+from slowapi.util import get_remote_address
+from starlette.requests import Request
+
+# Cloudflare edge IP ranges — https://www.cloudflare.com/ips/
+_CLOUDFLARE_CIDRS: tuple[str, ...] = (
+    # IPv4
+    "173.245.48.0/20",
+    "103.21.244.0/22",
+    "103.22.200.0/22",
+    "103.31.4.0/22",
+    "141.101.64.0/18",
+    "108.162.192.0/18",
+    "190.93.240.0/20",
+    "188.114.96.0/20",
+    "197.234.240.0/22",
+    "198.41.128.0/17",
+    "162.158.0.0/15",
+    "104.16.0.0/13",
+    "104.24.0.0/14",
+    "172.64.0.0/13",
+    "131.0.72.0/22",
+    # IPv6
+    "2400:cb00::/32",
+    "2606:4700::/32",
+    "2803:f800::/32",
+    "2405:b500::/32",
+    "2405:8100::/32",
+    "2a06:98c0::/29",
+    "2c0f:f248::/32",
+)
+
+# Pre-parse once at import so the per-request check never parses the list.
+_CLOUDFLARE_NETWORKS = tuple(ipaddress.ip_network(cidr) for cidr in _CLOUDFLARE_CIDRS)
+
+
+def _is_cloudflare_peer(host: str) -> bool:
+    """True if ``host`` is a Cloudflare edge IP whose forwarded headers we trust.
+
+    Returns False for anything that doesn't parse as an IP address (a test
+    client's ``"testclient"`` host, an empty peer, etc.) so the caller falls
+    back to peer-IP bucketing instead of raising.
+    """
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    # `ip in net` is False (not an error) across IPv4/IPv6 family mismatches.
+    return any(ip in net for net in _CLOUDFLARE_NETWORKS)
+
+
+def client_ip(request: Request) -> str:
+    """Resolve the real client IP for rate-limit bucketing.
+
+    Trusts Cloudflare's ``CF-Connecting-IP`` (then the left-most
+    ``X-Forwarded-For`` hop) **only** when the connecting peer is itself a
+    Cloudflare edge IP; otherwise returns the peer address. See the module
+    docstring for why gating on the peer is load-bearing for the login
+    brute-force limiter.
+    """
+    peer = get_remote_address(request)
+    if _is_cloudflare_peer(peer):
+        cf_ip = request.headers.get("cf-connecting-ip")
+        if cf_ip:
+            return cf_ip
+        forwarded = request.headers.get("x-forwarded-for")
+        if forwarded:
+            return forwarded.split(",")[0].strip()
+    return peer

--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,6 @@ from limits import RateLimitItem, parse
 from pydantic import BaseModel, EmailStr
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
-from slowapi.util import get_remote_address
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import auth_backend, current_active_user, fastapi_users
@@ -21,6 +20,7 @@ from app.auth.users import UserManager, get_user_manager
 from app.config import settings
 from app.database import get_async_session
 from app.features import router as features_router
+from app.limiting import client_ip
 from app.logging import setup_logging
 from app.models.user import User
 from app.routers import admin_router, user_consent_router, users_router
@@ -51,8 +51,10 @@ app.add_middleware(
     allow_headers=["Authorization", "Content-Type", "sentry-trace", "baggage"],
 )
 
-# Rate limiting
-limiter = Limiter(key_func=get_remote_address)
+# Rate limiting. ``client_ip`` keys on the real client IP behind Cloudflare
+# (CF-Connecting-IP, validated against CF's edge ranges) rather than the
+# shared edge peer — see app/limiting.py and issue #47.
+limiter = Limiter(key_func=client_ip)
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
@@ -295,7 +297,7 @@ async def rate_limit_auth(request: Request, call_next) -> Response:
     """
     rate_limit = _AUTH_RATE_LIMITS.get(f"{request.method} {request.url.path}")
     if rate_limit:
-        key = get_remote_address(request)
+        key = client_ip(request)
         if not limiter._limiter.hit(rate_limit, key):
             # window_stats: (reset_unix_ts, remaining). After a refused
             # hit, ``remaining`` is 0 and ``reset_unix_ts`` is when the

--- a/tests/test_client_ip.py
+++ b/tests/test_client_ip.py
@@ -1,0 +1,173 @@
+"""Tests for real-client-IP rate-limit bucketing behind Cloudflare (issue #47).
+
+The limiter used to key on ``get_remote_address`` = the peer/edge IP, which
+behind Cloudflare is a shared CF edge address. That bucketed the whole
+audience together: false login lockouts for legit users, and no real
+per-attacker brute-force limit.
+
+``app.limiting.client_ip`` now keys on ``CF-Connecting-IP`` — but only when
+the connecting peer is itself a Cloudflare edge IP, so a direct caller can't
+spoof the header to dodge the login limiter. These tests cover both the
+resolver in isolation and the limiter end-to-end through the middleware.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from starlette.requests import Request
+
+from app.limiting import _is_cloudflare_peer, client_ip
+
+# A real Cloudflare edge IP (104.16.0.0/13) and a non-Cloudflare public IP
+# (TEST-NET-3, reserved for documentation — never a real CF edge).
+CF_EDGE_IPV4 = "104.16.0.1"
+CF_EDGE_IPV6 = "2606:4700::1"
+NON_CF_IPV4 = "203.0.113.10"
+
+
+def _make_request(
+    headers: dict[str, str] | None = None, peer: str | None = CF_EDGE_IPV4
+) -> Request:
+    """Build a minimal ASGI ``Request`` with the given headers and TCP peer."""
+    raw_headers = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/auth/jwt/login",
+        "headers": raw_headers,
+        "client": (peer, 0) if peer is not None else None,
+    }
+    return Request(scope)
+
+
+# --- _is_cloudflare_peer -------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "host,expected",
+    [
+        (CF_EDGE_IPV4, True),
+        (CF_EDGE_IPV6, True),
+        ("162.158.1.1", True),  # another CF range (162.158.0.0/15)
+        (NON_CF_IPV4, False),  # public, non-CF
+        ("127.0.0.1", False),  # loopback
+        ("10.0.0.1", False),  # private
+        ("testclient", False),  # unparseable host must not raise
+        ("", False),  # empty peer must not raise
+    ],
+)
+def test_is_cloudflare_peer(host: str, expected: bool) -> None:
+    assert _is_cloudflare_peer(host) is expected
+
+
+# --- client_ip: trusted (peer is Cloudflare) -----------------------------
+
+
+def test_cf_peer_trusts_cf_connecting_ip() -> None:
+    req = _make_request({"cf-connecting-ip": "198.51.100.7"}, peer=CF_EDGE_IPV4)
+    assert client_ip(req) == "198.51.100.7"
+
+
+def test_cf_peer_falls_back_to_left_most_xff_hop() -> None:
+    # No CF-Connecting-IP: use the original client, the left-most XFF hop.
+    req = _make_request({"x-forwarded-for": "198.51.100.7, 104.16.0.1"}, peer=CF_EDGE_IPV4)
+    assert client_ip(req) == "198.51.100.7"
+
+
+def test_cf_connecting_ip_wins_over_xff() -> None:
+    req = _make_request(
+        {"cf-connecting-ip": "198.51.100.7", "x-forwarded-for": "10.10.10.10"},
+        peer=CF_EDGE_IPV4,
+    )
+    assert client_ip(req) == "198.51.100.7"
+
+
+def test_cf_peer_without_forwarded_headers_returns_peer() -> None:
+    req = _make_request({}, peer=CF_EDGE_IPV4)
+    assert client_ip(req) == CF_EDGE_IPV4
+
+
+def test_ipv6_cf_peer_trusts_header() -> None:
+    req = _make_request({"cf-connecting-ip": "198.51.100.7"}, peer=CF_EDGE_IPV6)
+    assert client_ip(req) == "198.51.100.7"
+
+
+# --- client_ip: untrusted (peer is NOT Cloudflare) — anti-spoof ----------
+
+
+def test_non_cf_peer_ignores_spoofed_cf_connecting_ip() -> None:
+    """The core security guarantee: a direct caller cannot spoof
+    CF-Connecting-IP to escape the limiter — we key on their real peer."""
+    req = _make_request({"cf-connecting-ip": "10.0.0.1"}, peer=NON_CF_IPV4)
+    assert client_ip(req) == NON_CF_IPV4
+
+
+def test_non_cf_peer_ignores_spoofed_xff() -> None:
+    req = _make_request({"x-forwarded-for": "10.0.0.1"}, peer=NON_CF_IPV4)
+    assert client_ip(req) == NON_CF_IPV4
+
+
+def test_unparseable_peer_returns_peer_and_ignores_headers() -> None:
+    req = _make_request({"cf-connecting-ip": "10.0.0.1"}, peer="testclient")
+    assert client_ip(req) == "testclient"
+
+
+# --- end-to-end through the rate-limit middleware ------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_limiter():
+    """Reset the process-global limiter storage around every test so the
+    population starts clean regardless of test order."""
+    from app.main import limiter
+
+    try:
+        limiter._limiter.storage.reset()
+    except Exception:
+        pass
+    yield
+    try:
+        limiter._limiter.storage.reset()
+    except Exception:
+        pass
+
+
+async def _login(c: AsyncClient, cf_ip: str):
+    # Body content is irrelevant — the limiter runs in middleware before the
+    # route — but send a realistic form so the allowed path is a clean 400,
+    # not a 422.
+    return await c.post(
+        "/auth/jwt/login",
+        data={"username": "nobody@example.com", "password": "x"},
+        headers={"cf-connecting-ip": cf_ip},
+    )
+
+
+async def test_login_limiter_buckets_per_real_client_behind_cloudflare() -> None:
+    """With a Cloudflare edge as the peer, the 5/min login budget is spent
+    per real client (CF-Connecting-IP), not shared across the edge."""
+    from app.main import app
+
+    transport = ASGITransport(app=app, client=(CF_EDGE_IPV4, 0))
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        # Real client A spends its whole budget...
+        for _ in range(5):
+            resp = await _login(c, "198.51.100.1")
+            assert resp.status_code != 429, resp.text
+        # ...and is then limited.
+        assert (await _login(c, "198.51.100.1")).status_code == 429
+        # A *different* real client sharing the same CF edge is unaffected —
+        # the bug this fixes would have 429'd them too.
+        assert (await _login(c, "198.51.100.2")).status_code != 429
+
+
+async def test_spoofed_cf_header_from_non_cf_peer_cannot_dodge_limit(
+    client: AsyncClient,
+) -> None:
+    """The default test peer (127.0.0.1) is not a CF edge, so a rotating
+    CF-Connecting-IP is untrusted and must NOT mint fresh buckets."""
+    statuses = [(await _login(client, f"198.51.100.{i}")).status_code for i in range(7)]
+    assert 429 in statuses, (
+        f"spoofing distinct CF-Connecting-IPs from a non-CF peer dodged the limit: {statuses}"
+    )


### PR DESCRIPTION
## Problem

The slowapi limiter keyed on `get_remote_address` = `request.client.host`, which behind Cloudflare (`auth.criticalbit.gg` is in the CF-proxied zone) is the **CF edge IP**, shared by every client routed through that edge. So the limiter bucketed the whole audience behind a handful of edge IPs instead of per real client.

On the `POST /auth/jwt/login` limiter (`app/main.py`) this is doubly bad: keyed on the edge IP it (a) causes **false lockouts** for legit users sharing a CF edge under load, and (b) doesn't actually limit per-attacker — so the brute-force protection isn't doing its job. Same root cause as the 429 storm in `aoe2-live-standings-api#176`.

## Fix

New `app/limiting.py` with a `client_ip` key func that reads the real client IP from `CF-Connecting-IP` (then the left-most `X-Forwarded-For` hop) — but **only when the connecting peer is itself within Cloudflare's published IP ranges**. Any other peer (a direct hit to the Cloud Run origin, a spoof attempt, a local test client) falls back to the peer address.

That peer check is the load-bearing difference from blanket header-trust: the `*.run.app` origin is publicly reachable (no ingress lock in `deploy.yml`), so blindly trusting `CF-Connecting-IP` would let a direct caller send a fresh value per request and walk straight past the login limiter — worse than the edge-IP bug. Gating on the peer being a real CF edge closes that by construction.

Wired into both the `Limiter` key func and the `rate_limit_auth` middleware.

## Test plan

- [x] `uv run pytest` — **148 passed, 1 skipped**
- [x] `uv run ruff check .` + `ruff format --check` — clean
- New `tests/test_client_ip.py` (18 tests):
  - Resolver units: CF peer trusts `CF-Connecting-IP` / falls back to the left-most XFF hop / returns peer with no headers; IPv6 CF peer; unparseable peer doesn't raise.
  - **Anti-spoof:** a non-CF peer's spoofed `CF-Connecting-IP` / `X-Forwarded-For` is ignored — keyed on the real peer.
  - End-to-end through the middleware: with a CF edge as the peer, the 5/min login budget is spent **per real client** (one client's lockout doesn't touch another sharing the edge); a rotating spoofed header from a non-CF peer **cannot** dodge the limit.

## Notes

- Cloudflare's ranges are embedded from https://www.cloudflare.com/ips/ (stable, rarely change); if CF adds a range we don't list, requests via it degrade safely to peer-IP bucketing rather than failing open.
- Optional defense-in-depth follow-up: lock Cloud Run ingress to the load balancer / Cloudflare. Not required given the peer-range validation, but belt-and-suspenders.
- The connection-pool / `max_connections` / stale-revision items the issue also mentions are out of scope here; can file a separate follow-up.

Closes #47
