### PR TITLE
ci(deploy): cap max-instances and prune stale Cloud Run revisions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,11 @@ env:
   SERVICE_NAME: criticalbit-auth-api
   MIGRATE_JOB_NAME: criticalbit-auth-api-migrate
   IMAGE: us-east1-docker.pkg.dev/criticalbit-production/criticalbit-auth-api/criticalbit-auth-api
+  # Cap horizontal scale so DB connections stay bounded:
+  # (DB_POOL_SIZE + DB_MAX_OVERFLOW) × MAX_INSTANCES + migrate-job + headroom
+  # must stay under Cloud SQL max_connections. 10 × 10/instance = ~100; raise
+  # alongside the Cloud SQL tier. See app/.env.example for the formula.
+  MAX_INSTANCES: 10
 
 jobs:
   ci:
@@ -73,5 +78,30 @@ jobs:
             --image "$IMAGE_TAG" \
             --region "${{ env.GCP_REGION }}" \
             --project "${{ env.GCP_PROJECT }}" \
+            --max-instances "${{ env.MAX_INSTANCES }}" \
             --update-secrets=SENTRY_DSN=auth-sentry-dsn:latest \
             --update-env-vars="SENTRY_RELEASE=$COMMIT_SHA"
+
+      # Cloud Run never auto-prunes old revisions, and a revision pinned by
+      # min-instances keeps an instance + its DB connection pool alive even at
+      # 0% traffic — so accumulation can silently saturate Cloud SQL's
+      # max_connections (the 2026-06-01 morning outage; aoe2-live-standings-api#171).
+      # Keep the 2 newest (current + one rollback) and delete the rest.
+      # Best-effort: never fail the deploy that just succeeded.
+      - name: Prune stale Cloud Run revisions
+        continue-on-error: true
+        run: |
+          set +e
+          stale=$(gcloud run revisions list \
+            --service "${{ env.SERVICE_NAME }}" \
+            --region "${{ env.GCP_REGION }}" \
+            --project "${{ env.GCP_PROJECT }}" \
+            --sort-by '~metadata.creationTimestamp' \
+            --format 'value(metadata.name)' | tail -n +3)
+          for rev in $stale; do
+            echo "Deleting stale revision: $rev"
+            gcloud run revisions delete "$rev" \
+              --region "${{ env.GCP_REGION }}" \
+              --project "${{ env.GCP_PROJECT }}" \
+              --quiet || true
+          done


### PR DESCRIPTION
Follow-up to #47 (the infra hardening it flagged from `aoe2-live-standings-api`'s 2026-06-01 launch incident). Mirrors aoe2 `#171`. Pairs with #49 (connection-pool sizing).

## Problem

`deploy.yml` set **no `--max-instances`** (Cloud Run default = 100) and never pruned old revisions. Two compounding leaks toward Cloud SQL's `max_connections`:

1. **Unbounded scale** — at the default cap, 100 instances × the per-instance pool can demand far more connections than any small Cloud SQL tier allows.
2. **Revision accumulation** — Cloud Run never auto-prunes; a revision pinned by `min-instances>0` keeps an instance **and its DB pool** alive at 0% traffic. Enough stale revisions silently saturate the cap (the morning connection-exhaustion outage in the referenced incident).

## Change

- **Cap scale:** `MAX_INSTANCES=10` env var, passed as `--max-instances` on the service update. Bounds worst-case connections together with the pool sizing in #49: `(5+5)/instance × 10 = ~100`, plus the migrate job + headroom — sized to be raised alongside the Cloud SQL tier.
- **Prune revisions:** a best-effort post-deploy step that keeps the 2 newest revisions (current + one rollback) and deletes the rest. `continue-on-error: true` + per-delete `|| true` so it can never fail a deploy that already succeeded.

## Validation

- [x] `deploy.yml` parses as valid YAML; the new step is recognized by the workflow parser.
- [x] Prune shell script passes `bash -n` syntax check.
- No untrusted `github.event.*` input is used in any `run:` block (only static `env:` vars + `github.sha`), so there's no workflow-injection surface.
- Runtime behavior (instance cap applied, revisions pruned) is exercised on the **next deploy to main** — it can't be tested in CI.

## Notes

- This is breathing room, not a response to a current bottleneck. The remaining lever — verifying/raising the Cloud SQL tier's `max_connections` (aoe2 `#173`) — is infra (gcloud/Terraform) and out of scope here.
- If the deploy service account lacks `run.revisions.delete`, the prune step no-ops harmlessly (best-effort); grant the permission to activate it.
