### PR TITLE
ci(deploy): right-size max-instances for db-g1-small

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,10 +7,11 @@ DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/criticalbit_a
 #   (DB_POOL_SIZE + DB_MAX_OVERFLOW) × max-instances + migrate-job + headroom
 #       ≤ Cloud SQL max_connections
 #
-# Defaults below (10/instance) fit a 200-connection tier comfortably at
-# max-instances=10 (see .github/workflows/deploy.yml). For a ~100-connection
-# tier, lower max-instances or the pool. Defaults are applied to Postgres
-# only; SQLite (dev/test) ignores them.
+# Defaults below are 10/instance; with max-instances=4 (see
+# .github/workflows/deploy.yml) that's ~40 peak, sized for criticalbit-db on
+# db-g1-small (~50 default max_connections). Bumping the tier? Raise
+# max-instances and re-confirm max_connections. Applied to Postgres only;
+# SQLite (dev/test) ignores them.
 # DB_POOL_SIZE=5          # persistent connections kept open per instance
 # DB_MAX_OVERFLOW=5       # extra burst connections above pool_size
 # DB_POOL_TIMEOUT=30      # seconds to wait for a free connection before erroring

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,9 +16,10 @@ env:
   IMAGE: us-east1-docker.pkg.dev/criticalbit-production/criticalbit-auth-api/criticalbit-auth-api
   # Cap horizontal scale so DB connections stay bounded:
   # (DB_POOL_SIZE + DB_MAX_OVERFLOW) × MAX_INSTANCES + migrate-job + headroom
-  # must stay under Cloud SQL max_connections. 10 × 10/instance = ~100; raise
-  # alongside the Cloud SQL tier. See app/.env.example for the formula.
-  MAX_INSTANCES: 10
+  # must stay under Cloud SQL max_connections. At 10/instance, 4 instances =
+  # ~40 peak — under db-g1-small's ~50 default (criticalbit-db). Raise this
+  # alongside the tier, re-confirming max_connections first. See .env.example.
+  MAX_INSTANCES: 4
 
 jobs:
   ci:


### PR DESCRIPTION
Follow-up to #47 / #49 / #50, now that we know the actual DB tier.

## What we found

`criticalbit-db` (the auth-api's Cloud SQL instance in `criticalbit-production`) is **`db-f1-micro`** with no `max_connections` flag → the tier default, which for f1-micro is small (~25). We're bumping it to **`db-g1-small`** (next tier up, ~50 default) — enough breathing room without the dedicated-core tier the aoe2 API needed.

## Why this change

The instance cap shipped in #50 was sized for a large tier: `MAX_INSTANCES=10` × 10 connections/instance = **~100 peak**, which overshoots g1-small's ~50 ceiling. It's been safe only because effective scale is ~1 instance at current traffic.

Drop the cap to **`MAX_INSTANCES=4`** → ~40 peak, under g1-small's default with headroom for the Alembic migrate job and Postgres's reserved connections.

```
(pool_size 5 + max_overflow 5) × 4 instances = 40 peak  ≤  ~50 (db-g1-small)
```

Everything else from #49/#50 — configurable pool, `pool_pre_ping`, `pool_recycle`, and the stale-revision prune — is unchanged. This only retunes the one number.

## Paired infra change (out of repo)

This repo doesn't manage Cloud SQL as code, so the tier bump is applied via gcloud separately:

```
gcloud sql instances patch criticalbit-db --tier=db-g1-small \
  --project criticalbit-production --account <you>
```

⚠️ That triggers a short Cloud SQL **restart** (a few minutes of DB unavailability → auth blips), so run it in a low-traffic window. The two changes are independent and each is strictly safer than today, so order doesn't matter — but they pair to land at 40-peak-under-~50.

## Validation

- [x] `deploy.yml` parses as valid YAML; `MAX_INSTANCES=4`.
- No Python changed; CI `ruff`/`pytest` unaffected.
- Effective `max_connections` should be re-confirmed on g1-small after the bump (`SHOW max_connections;`); if it's higher than ~50, `MAX_INSTANCES` can be raised.
